### PR TITLE
add: podgląd listy plików

### DIFF
--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -2,11 +2,16 @@
 from __future__ import annotations
 
 import os
+from typing import List, Dict
 
 import pathspec
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication
-from PyQt5.QtWidgets import QFileDialog, QListWidgetItem, QMessageBox
+from PyQt5.QtGui import QGuiApplication, QFont
+from PyQt5.QtWidgets import (
+    QFileDialog,
+    QListWidgetItem,
+    QMessageBox,
+)
 
 from prompt_assistant.config import MAX_DIR_SIZE, WARNING_TOKEN_LIMIT, CRITICAL_TOKEN_LIMIT
 from prompt_assistant.utils import (
@@ -16,25 +21,32 @@ from prompt_assistant.utils import (
     build_gitignore_spec,
 )
 from .ui import PromptAssistantWindow
+from .preview_dialog import FilePreviewDialog
 
 
+# --------------------------------------------------------------------------- UI
 def _update_token_label(window: PromptAssistantWindow) -> None:
+    """Przelicza tokeny promptu i załączników z pominięciem wykluczonych plików."""
     prompt_text = window.text_edit.toPlainText()
     window.prompt_tokens = count_tokens(prompt_text) if prompt_text else 0
 
     attach_tokens = 0
-    for _name, content in window.attached_files:
-        attach_tokens += count_tokens(content)
+    # --- pliki pojedyncze
+    for f in window.attached_files:
+        if not f["excluded"]:
+            attach_tokens += count_tokens(f["content"])
+    # --- pliki z katalogów
     for d in window.attached_dirs:
-        attach_tokens += count_tokens(d["tree"])
-        for _rel, content in d["files"]:
-            attach_tokens += count_tokens(content)
-    window.attachments_tokens = attach_tokens
+        attach_tokens += count_tokens(d["tree"])  # drzewo jest zawsze liczone
+        for f in d["files"]:
+            if not f["excluded"]:
+                attach_tokens += count_tokens(f["content"])
 
-    total = window.prompt_tokens + window.attachments_tokens
+    window.attachments_tokens = attach_tokens
+    total = window.prompt_tokens + attach_tokens
     window.total_tokens = total
     window.token_label.setText(
-        f"Tokeny: prompt: {window.prompt_tokens} | pliki: {window.attachments_tokens} | suma: {total}"
+        f"Tokeny: prompt: {window.prompt_tokens} | pliki: {attach_tokens} | suma: {total}"
     )
     if total > CRITICAL_TOKEN_LIMIT:
         window.token_label.setStyleSheet("color: red; font-weight: bold")
@@ -48,18 +60,35 @@ def _toggle_gitignore(window: PromptAssistantWindow, state: int) -> None:
     window.ignore_gitignored = state == Qt.Checked
 
 
+# -------------------------------------------------------------------- helpers –
+def _create_file_item(
+    window: PromptAssistantWindow,
+    display_name: str,
+    file_obj: dict,
+    is_dir_file: bool = False,
+) -> None:
+    """Dodaje wpis do QListWidget i przypina obiekt pliku w UserRole."""
+    item = QListWidgetItem(display_name)
+    item.setData(Qt.UserRole, ("dir_file" if is_dir_file else "file", file_obj))
+    lw = window.files_list
+    lw.addItem(item)
+
+
+# --------------------------------------------------------------------- actions
 def attach_files(window: PromptAssistantWindow) -> None:
     paths, _ = QFileDialog.getOpenFileNames(window, "Wybierz pliki...", "", "*.*")
     for path in paths:
-        if os.path.isfile(path):
-            try:
-                with open(path, encoding="utf-8") as f:
-                    content = f.read()
-                name = os.path.basename(path)
-                window.attached_files.append((name, content))
-                window.files_list.addItem(QListWidgetItem(name))
-            except Exception:
-                pass
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            name = os.path.basename(path)
+            file_obj = {"name": name, "content": content, "excluded": False}
+            window.attached_files.append(file_obj)
+            _create_file_item(window, name, file_obj)
+        except Exception:
+            pass
     _update_token_label(window)
 
 
@@ -67,7 +96,8 @@ def attach_directory(window: PromptAssistantWindow) -> None:
     dir_path = QFileDialog.getExistingDirectory(window, "Wybierz katalog...", "")
     if not dir_path:
         return
-    # size check
+
+    # --- Size sanity-check
     total_size = 0
     for root, dirs, files in os.walk(dir_path):
         if ".git" in dirs:
@@ -78,57 +108,88 @@ def attach_directory(window: PromptAssistantWindow) -> None:
             except OSError:
                 pass
         if total_size > MAX_DIR_SIZE:
-            QMessageBox.warning(window, "Zbyt duży katalog", f"{os.path.basename(dir_path)} > 1 GB")
+            QMessageBox.warning(window, "Zbyt duży katalog", f"{os.path.basename(dir_path)} > 1 GB")
             return
-    git_spec = build_gitignore_spec(dir_path) if window.ignore_gitignored else None
-    custom = [p.strip() for p in window.exclude_edit.text().split(',') if p.strip()]
-    custom_spec = pathspec.PathSpec.from_lines('gitwildmatch', custom) if custom else None
 
-    collected = []
-    skipped = {'binary':0, 'git':0, 'custom':0}
-    base = len(dir_path)+1
+    git_spec = build_gitignore_spec(dir_path) if window.ignore_gitignored else None
+    custom = [p.strip() for p in window.exclude_edit.text().split(",") if p.strip()]
+    custom_spec = pathspec.PathSpec.from_lines("gitwildmatch", custom) if custom else None
+
+    collected: List[Dict] = []
+    skipped = {"binary": 0, "git": 0, "custom": 0}
+    base = len(dir_path) + 1
+
     for root, dirs, files in os.walk(dir_path):
-        if ".git" in dirs: dirs.remove(".git")
+        if ".git" in dirs:
+            dirs.remove(".git")
         for f in files:
             full = os.path.join(root, f)
-            rel = full[base:].replace(os.sep,'/')
-            if git_spec and git_spec.match_file(rel): skipped['git']+=1; continue
-            if custom_spec and custom_spec.match_file(rel): skipped['custom']+=1; continue
-            if is_binary(full): skipped['binary']+=1; continue
+            rel = full[base:].replace(os.sep, "/")
+            # --- filters
+            if git_spec and git_spec.match_file(rel):
+                skipped["git"] += 1
+                continue
+            if custom_spec and custom_spec.match_file(rel):
+                skipped["custom"] += 1
+                continue
+            if is_binary(full):
+                skipped["binary"] += 1
+                continue
+            # --- collect
             try:
                 with open(full, encoding="utf-8") as fh:
-                    collected.append((rel, fh.read()))
+                    collected.append({"rel": rel, "content": fh.read(), "excluded": False})
             except Exception:
-                skipped['binary']+=1
+                skipped["binary"] += 1
+
     if not collected:
         QMessageBox.information(window, "Brak plików", "Nie znaleziono plików tekstowych.")
         return
-    tree = render_tree_structure([r for r,_ in collected])
+
+    tree = render_tree_structure([f["rel"] for f in collected])
     name = os.path.basename(dir_path)
-    window.attached_dirs.append({'name':name,'files':collected,'tree':tree})
-    item = QListWidgetItem(f"[DIR] {name} ({len(collected)})")
-    window.files_list.addItem(item)
-    msgs = [f"{v} {k}" for k,v in skipped.items() if v]
-    if msgs: QMessageBox.information(window,"Pominięto",", ".join(msgs))
+    window.attached_dirs.append({"name": name, "files": collected, "tree": tree})
+
+    # --- UI items
+    for f in collected:
+        _create_file_item(window, f"{name}/{f['rel']}", f, is_dir_file=True)
+
+    # --- info o pominieciach
+    msgs = [f"{v} {k}" for k, v in skipped.items() if v]
+    if msgs:
+        QMessageBox.information(window, "Pominięto", ", ".join(msgs))
+
     _update_token_label(window)
 
 
 def copy_text(window: PromptAssistantWindow) -> None:
-    parts=[]
-    p=window.text_edit.toPlainText()
+    """Buduje prompt + wszystkie załączniki (bez excluded) i kopiuje do clipboard."""
+    parts: List[str] = []
+    p = window.text_edit.toPlainText()
+    if p:
+        parts.append(p)
+
+    # --- katalogi
     for d in window.attached_dirs:
         parts.append("<directories>")
-        parts.extend(d['tree'].splitlines())
+        parts.extend(d["tree"].splitlines())
         parts.append("</directories>")
-        for r,c in d['files']:
-            parts.append(f"<file={d['name']}/{r}>")
-            parts.extend(c.splitlines())
-            parts.append(f"</file={d['name']}/{r}>")
-    for n,c in window.attached_files:
-        parts.append(f"<file={n}>")
-        parts.extend(c.splitlines())
-        parts.append(f"</file={n}>")
-    QGuiApplication.clipboard().setText(p+"\n"+"\n".join(parts))
+        for f in d["files"]:
+            if f["excluded"]:
+                continue
+            parts.append(f"<file={d['name']}/{f['rel']}>")
+            parts.extend(f["content"].splitlines())
+            parts.append(f"</file={d['name']}/{f['rel']}>")
+
+    # --- pliki pojedyncze
+    for f in window.attached_files:
+        if f["excluded"]:
+            continue
+        parts.append(f"<file={f['name']}>")
+        parts.extend(f["content"].splitlines())
+        parts.append(f"</file={f['name']}>")
+
+    QGuiApplication.clipboard().setText("\n".join(parts))
 
 
 def clear_all(window: PromptAssistantWindow) -> None:
@@ -136,15 +197,31 @@ def clear_all(window: PromptAssistantWindow) -> None:
     window.files_list.clear()
     window.attached_dirs.clear()
     window.attached_files.clear()
-    window.prompt_tokens=window.attachments_tokens=window.total_tokens=0
+    window.prompt_tokens = window.attachments_tokens = window.total_tokens = 0
     window.token_label.setText("Tokeny: prompt: 0 | pliki: 0 | suma: 0")
 
 
+# ----------------------------------------------------------------- preview slot
+def preview_file(window: PromptAssistantWindow, item: QListWidgetItem) -> None:
+    """Obsługa podwójnego kliknięcia na element listy."""
+    role = item.data(Qt.UserRole)
+    if not role:
+        return
+    kind, file_obj = role
+    if kind not in ("file", "dir_file"):
+        return
+    dlg = FilePreviewDialog(window, item, file_obj, is_dir_file=(kind == "dir_file"))
+    dlg.exec_()
+
+
+# ----------------------------------------------------------------------- setup
 def setup_ui(window: PromptAssistantWindow) -> None:
     from .ui import build_ui
+
     build_ui(window)
 
 
 def connect_signals(window: PromptAssistantWindow) -> None:
     from .ui import bind_signals
+
     bind_signals(window)

--- a/prompt_assistant/gui/preview_dialog.py
+++ b/prompt_assistant/gui/preview_dialog.py
@@ -1,0 +1,100 @@
+'''File preview & management dialog.'''  
+from __future__ import annotations
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import (
+    QDialog,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPlainTextEdit,
+    QPushButton,
+    QCheckBox,
+    QListWidgetItem,
+)
+
+from prompt_assistant.utils import count_tokens
+
+class FilePreviewDialog(QDialog):
+    """QDialog pokazujący zawartość pliku z opcją wykluczenia lub usunięcia."""
+
+    def __init__(
+        self,
+        window,                # główne okno – potrzebne do odświeżenia stanu
+        list_item: QListWidgetItem,  # odpowiadający wpis w QListWidget
+        file_obj: dict,        # słownik pliku {'name'/ 'rel', 'content', 'excluded'}
+        is_dir_file: bool,     # czy plik pochodzi z katalogu
+        parent=None,
+    ) -> None:
+        super().__init__(parent or window)
+        self.setWindowTitle(file_obj.get("name", file_obj.get("rel")))
+        self.setMinimumWidth(640)
+        self.window = window
+        self.list_item = list_item
+        self.file_obj = file_obj
+        self.is_dir_file = is_dir_file
+
+        # ---- UI ----------------------------------------------------------------
+        vbox = QVBoxLayout(self)
+
+        header = QLabel(
+            f"{self.window.windowTitle().split('—')[0]} — "
+            f"{file_obj.get('name', file_obj.get('rel'))} "
+            f"— {count_tokens(file_obj['content'])} tokenów"
+        )
+        header.setWordWrap(True)
+        vbox.addWidget(header)
+
+        self.viewer = QPlainTextEdit(file_obj["content"])
+        self.viewer.setReadOnly(True)
+        vbox.addWidget(self.viewer, 1)
+
+        self.exclude_cb = QCheckBox("✅ Wyklucz ten plik z promptu")
+        self.exclude_cb.setChecked(file_obj["excluded"])
+        self.exclude_cb.stateChanged.connect(self._toggle_exclude)
+        vbox.addWidget(self.exclude_cb)
+
+        # ---- Buttons -----------------------------------------------------------
+        hbox = QHBoxLayout()
+        self.delete_btn = QPushButton("❌ Usuń plik z listy")
+        self.delete_btn.clicked.connect(self._delete_file)
+        self.close_btn = QPushButton("Zamknij")
+        self.close_btn.clicked.connect(self.accept)
+        hbox.addStretch(1)
+        hbox.addWidget(self.delete_btn)
+        hbox.addWidget(self.close_btn)
+        vbox.addLayout(hbox)
+
+    # --------------------------------------------------------------------- slots
+    def _toggle_exclude(self, state: int) -> None:
+        """Aktualizuje status excluded i formatowanie w liście."""
+        # Late import to avoid circular import
+        from prompt_assistant.gui.controllers import _update_token_label
+
+        self.file_obj["excluded"] = state == Qt.Checked
+        font: QFont = self.list_item.font()
+        font.setStrikeOut(self.file_obj["excluded"])
+        self.list_item.setFont(font)
+        _update_token_label(self.window)
+
+    def _delete_file(self) -> None:
+        """Usuwa plik ze wszystkich struktur + z UI."""
+        # Late import to avoid circular import
+        from prompt_assistant.gui.controllers import _update_token_label
+
+        lw = self.window.files_list
+        row = lw.row(self.list_item)
+        lw.takeItem(row)
+
+        # Usuń z modelu
+        if self.file_obj in self.window.attached_files:
+            self.window.attached_files.remove(self.file_obj)
+        else:  # szukaj w katalogach
+            for d in self.window.attached_dirs:
+                if self.file_obj in d["files"]:
+                    d["files"].remove(self.file_obj)
+                    break
+
+        _update_token_label(self.window)
+        self.accept()

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -17,13 +17,15 @@ from PyQt5.QtWidgets import (
 
 __all__ = ["PromptAssistantWindow", "build_ui", "bind_signals"]
 
+
 class PromptAssistantWindow(QMainWindow):
     """Main window for the Prompt Assistant GUI."""
+
     def __init__(self) -> None:
         super().__init__()
         # Initialize state
-        self.attached_dirs = []
-        self.attached_files = []
+        self.attached_dirs = []   # [{'name', 'tree', 'files':[...]}]
+        self.attached_files = []  # [{'name', 'content', 'excluded'}]
         self.prompt_tokens = 0
         self.attachments_tokens = 0
         self.total_tokens = 0
@@ -87,6 +89,7 @@ def bind_signals(window: PromptAssistantWindow) -> None:
         attach_directory,
         copy_text,
         clear_all,
+        preview_file,  # <------ nowa funkcja
     )
 
     window.text_edit.textChanged.connect(lambda: _update_token_label(window))
@@ -95,3 +98,4 @@ def bind_signals(window: PromptAssistantWindow) -> None:
     window.attach_dir_button.clicked.connect(lambda: attach_directory(window))
     window.copy_button.clicked.connect(lambda: copy_text(window))
     window.clear_button.clicked.connect(lambda: clear_all(window))
+    window.files_list.itemDoubleClicked.connect(lambda item: preview_file(window, item))


### PR DESCRIPTION
Dodany podgląd listy plików:
- Podgląd – double-click uruchamia FilePreviewDialog z treścią i liczbą tokenów.
- Wykluczanie – checkbox → plik nie wlicza się do tokenów ani Copy, a nazwa w liście jest przekreślona.
- Usuwanie – przycisk ❌ natychmiast usuwa plik z listy i wewnętrznych struktur.
- Aktualizacja UI – po zamknięciu dialogu liczniki i widok listy są w pełni zaktualizowane.
- Copy / update_token_count – ignorują pliki oznaczone excluded.