### PR TITLE
add: przycisk pokazujący rozkład tokenów

### DIFF
--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -11,6 +11,12 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QListWidgetItem,
     QMessageBox,
+    QDialog,
+    QVBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QHBoxLayout,
 )
 
 from prompt_assistant.config import MAX_DIR_SIZE, WARNING_TOKEN_LIMIT, CRITICAL_TOKEN_LIMIT
@@ -37,7 +43,7 @@ def _update_token_label(window: PromptAssistantWindow) -> None:
             attach_tokens += count_tokens(f["content"])
     # --- pliki z katalogów
     for d in window.attached_dirs:
-        attach_tokens += count_tokens(d["tree"])  # drzewo jest zawsze liczone
+        attach_tokens += count_tokens(d["tree"])
         for f in d["files"]:
             if not f["excluded"]:
                 attach_tokens += count_tokens(f["content"])
@@ -177,17 +183,17 @@ def copy_text(window: PromptAssistantWindow) -> None:
         for f in d["files"]:
             if f["excluded"]:
                 continue
-            parts.append(f"<file={d['name']}/{f['rel']}>")
+            parts.append(f"<file path='{d['name']}/{f['rel']}'>")
             parts.extend(f["content"].splitlines())
-            parts.append(f"</file={d['name']}/{f['rel']}>")
+            parts.append(f"</file>")
 
     # --- pliki pojedyncze
     for f in window.attached_files:
         if f["excluded"]:
             continue
-        parts.append(f"<file={f['name']}>")
+        parts.append(f"<file path='{f['name']}'>")
         parts.extend(f["content"].splitlines())
-        parts.append(f"</file={f['name']}>")
+        parts.append(f"</file>")
 
     QGuiApplication.clipboard().setText("\n".join(parts))
 
@@ -213,6 +219,72 @@ def preview_file(window: PromptAssistantWindow, item: QListWidgetItem) -> None:
     dlg = FilePreviewDialog(window, item, file_obj, is_dir_file=(kind == "dir_file"))
     dlg.exec_()
 
+def show_token_distribution(window: PromptAssistantWindow) -> None:
+    """Wyświetla modalne okno z rozkładem tokenów promptu i załączonych plików."""
+    # Dynamiczne liczenie
+    prompt_text = window.text_edit.toPlainText() or ""
+    prompt_tokens = count_tokens(prompt_text)
+
+    # Pliki pojedyncze
+    file_counts: List[tuple[str, int]] = [
+        (f['name'], count_tokens(f['content']))
+        for f in window.attached_files
+        if not f['excluded']
+    ]
+    file_counts.sort(key=lambda x: x[1], reverse=True)
+
+    # Katalogi
+    dir_data: List[tuple[str, int, List[tuple[str, int]]]] = []
+    for d in window.attached_dirs:
+        tree_tokens = count_tokens(d['tree'])
+        files = [
+            (f['rel'], count_tokens(f['content']))
+            for f in d['files']
+            if not f['excluded']
+        ]
+        files.sort(key=lambda x: x[1], reverse=True)
+        dir_data.append((d['name'], tree_tokens, files))
+
+    # Budowanie raportu
+    lines: List[str] = []
+    lines.append("Prompt")
+    lines.append(f"  prompt: {prompt_tokens} tokenów")
+    lines.append("")
+    if file_counts:
+        lines.append("Pliki pojedyncze")
+        for name, tokens in file_counts:
+            lines.append(f"  {name}: {tokens} tokenów")
+        lines.append("")
+    if dir_data:
+        lines.append("Katalogi")
+        for dir_name, tree_tokens, files in dir_data:
+            lines.append(f"{dir_name}")
+            lines.append(f"  tree: {tree_tokens} tokenów")
+            for rel, tokens in files:
+                lines.append(f"  {rel}: {tokens} tokenów")
+            lines.append("")
+    report = "\n".join(lines)
+
+    # Tworzenie dialogu
+    dialog = QDialog(window)
+    dialog.setWindowTitle("Rozkład tokenów")
+    dialog.setMinimumWidth(600)
+    layout = QVBoxLayout(dialog)
+
+    # Raport w QPlainTextEdit
+    text = QPlainTextEdit(report)
+    text.setReadOnly(True)
+    layout.addWidget(text)
+
+    # Przyciski
+    btn_layout = QHBoxLayout()
+    btn_layout.addStretch(1)
+    btn_close = QPushButton("Zamknij")
+    btn_close.clicked.connect(dialog.accept)
+    btn_layout.addWidget(btn_close)
+    layout.addLayout(btn_layout)
+
+    dialog.exec_()
 
 # ----------------------------------------------------------------------- setup
 def setup_ui(window: PromptAssistantWindow) -> None:

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -183,7 +183,14 @@ def copy_text(window: PromptAssistantWindow) -> None:
         for f in d["files"]:
             if f["excluded"]:
                 continue
-            parts.append(f"<file path='{d['name']}/{f['rel']}'>")
+
+            rel_path = f["rel"]
+            if "/" in rel_path:
+                tag_path = f"/{rel_path}"
+            else:
+                tag_path = rel_path
+
+            parts.append(f"<file path='{tag_path}'>")
             parts.extend(f["content"].splitlines())
             parts.append(f"</file>")
 

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -79,6 +79,10 @@ def build_ui(window: PromptAssistantWindow) -> None:
     window.token_label = QLabel("Tokeny: prompt: 0 | pliki: 0 | suma: 0")
     status.addPermanentWidget(window.token_label)
 
+    # Nowy przycisk: Pokaż rozkład tokenów
+    window.show_token_dist_button = QPushButton("Pokaż rozkład tokenów")
+    status.addPermanentWidget(window.show_token_dist_button)
+
 
 def bind_signals(window: PromptAssistantWindow) -> None:
     """Connects UI events to controller functions."""
@@ -89,7 +93,8 @@ def bind_signals(window: PromptAssistantWindow) -> None:
         attach_directory,
         copy_text,
         clear_all,
-        preview_file,  # <------ nowa funkcja
+        preview_file,
+        show_token_distribution,
     )
 
     window.text_edit.textChanged.connect(lambda: _update_token_label(window))
@@ -99,3 +104,4 @@ def bind_signals(window: PromptAssistantWindow) -> None:
     window.copy_button.clicked.connect(lambda: copy_text(window))
     window.clear_button.clicked.connect(lambda: clear_all(window))
     window.files_list.itemDoubleClicked.connect(lambda item: preview_file(window, item))
+    window.show_token_dist_button.clicked.connect(lambda: show_token_distribution(window))


### PR DESCRIPTION
🚀 **Features**

- dla wygody dodany przycisk pokazujący rozkład tokenów, dzięki czemu można na szybko po załączenia katalogu przeanalizować które pliki w repozytorium "zjadają" najwięcej tokenów

🪲 **Bug Fixes**

- poprawione ścieżki wyświetlane w tagach `<file path=...>`
