### PR TITLE
PromptGlue v2: milestones M1-M4 + fixes

### DIFF
--- a/.agents/skills/codex-flow-apply-self-review-fixes/SKILL.md
+++ b/.agents/skills/codex-flow-apply-self-review-fixes/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: codex-flow-apply-self-review-fixes
+description: >
+  Użyj po wykonaniu self-review, gdy wykryto niespójności, naruszenia zasad lub
+  problemy jakościowe i trzeba wdrożyć wyłącznie poprawki wynikające z tego
+  przeglądu. Zachowaj zakres bieżącego milestone'u, nie dodawaj nowych funkcji
+  i nie przebudowuj architektury bez wyraźnej potrzeby wynikającej z review.
+  Po zakończeniu uruchom odpowiednie testy lub walidacje.
+---
+
+Zastosuj poprawki wynikające z self-review.
+
+Cel:
+- usunąć problemy wykryte podczas przeglądu
+- przywrócić zgodność z dokumentacją i zasadami projektu
+- poprawić jakość rozwiązania bez rozszerzania zakresu pracy
+
+Przebieg pracy:
+1. Przejrzyj wynik self-review i wybierz tylko poprawki rzeczywiście z niego wynikające.
+2. Oceń każdą poprawkę pod kątem zakresu:
+   - czy nadal mieści się w aktualnym milestone'ie
+   - czy nie wprowadza nowej funkcjonalności
+   - czy nie zmienia architektury bardziej, niż wymaga to problem
+3. Wdróż poprawki.
+4. Zaktualizuj testy lub dokumentację tylko wtedy, gdy jest to konieczne do domknięcia problemu.
+5. Uruchom odpowiednie testy lub walidacje.
+6. Podsumuj, jakie poprawki zostały wdrożone.
+
+Zasady:
+- nie zmieniaj zakresu milestone'u
+- nie dodawaj nowych funkcjonalności
+- nie wprowadzaj refaktoru wykraczającego poza potrzebę naprawy
+- jeśli poprawka okazuje się nowym zakresem pracy, zatrzymaj ją i zaznacz to w podsumowaniu
+- jeśli potrzebujesz doprecyzowania granicy zmian, użyj plików z `references/`
+- jeśli potrzebujesz uruchomić zestaw walidacji po poprawkach, użyj skryptów z `scripts/`
+
+Wynik:
+- wypisz, które poprawki zostały wdrożone
+- wskaż uruchomione testy lub walidacje
+- zaznacz wszystko, czego świadomie nie wdrożono, bo wykraczało poza zakres self-review

--- a/.agents/skills/codex-flow-apply-self-review-fixes/references/COMMON-FIXES.md
+++ b/.agents/skills/codex-flow-apply-self-review-fixes/references/COMMON-FIXES.md
@@ -1,0 +1,9 @@
+# Typowe poprawki po self-review
+
+- dopisanie lub poprawa testu
+- korekta logiki warunkowej
+- usunięcie martwego kodu
+- uproszczenie helpera
+- doprecyzowanie obsługi błędu
+- poprawa nazw zmiennych lub funkcji
+- aktualizacja README, STATUS.md albo ROADMAP.md, jeśli review wykazał niespójność

--- a/.agents/skills/codex-flow-apply-self-review-fixes/references/FIX-SCOPE.md
+++ b/.agents/skills/codex-flow-apply-self-review-fixes/references/FIX-SCOPE.md
@@ -1,0 +1,15 @@
+# Granica zakresu poprawek po self-review
+
+Dozwolone:
+- dopisanie brakującego testu
+- uproszczenie warunku lub przepływu sterowania
+- usunięcie duplikacji ograniczonej do obszaru zmiany
+- poprawa walidacji
+- poprawa README lub dokumentacji operacyjnej, jeśli review wykazał braki
+- mały refaktor konieczny do bezpiecznej naprawy problemu
+
+Niedozwolone bez nowej decyzji planistycznej:
+- dodawanie nowych ekranów, endpointów, funkcji i integracji
+- przebudowa architektury, której review nie wymaga wprost
+- szeroki refaktor niezwiązany bezpośrednio z wykrytym problemem
+- "przy okazji" poprawianie innych obszarów repo

--- a/.agents/skills/codex-flow-apply-self-review-fixes/scripts/run-post-fix-checks.sh
+++ b/.agents/skills/codex-flow-apply-self-review-fixes/scripts/run-post-fix-checks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Uruchom po poprawkach właściwe komendy walidacyjne dla tego repo."
+echo "Przykłady: testy, lint, typecheck, build, smoke tests."
+echo "Nie zgaduj komend — użyj tylko tych, które są zdefiniowane w projekcie."

--- a/.agents/skills/codex-flow-continue-project/SKILL.md
+++ b/.agents/skills/codex-flow-continue-project/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: codex-flow-continue-project
+description: >
+  Użyj, gdy otwierasz istniejący projekt w nowym kontekście i chcesz najpierw
+  odtworzyć stan pracy na podstawie spec.md, ROADMAP.md, STATUS.md i aktualnego
+  repozytorium. Ten skill tylko analizuje i streszcza stan projektu, wskazuje
+  aktualny milestone i niczego nie implementuje ani nie zmienia w plikach.
+---
+
+To jest kontynuacja istniejącego projektu.
+
+Kontekst:
+- przeczytaj `spec.md`
+- przeczytaj `ROADMAP.md`
+- przeczytaj `STATUS.md`
+- zapoznaj się z aktualnym stanem repozytorium
+
+Zasady:
+- nie reinterpretuj wcześniejszych decyzji
+- nie zmieniaj architektury bez wyraźnej prośby
+- trzymaj się roadmapy
+
+Po przeczytaniu:
+- krótko streść projekt
+- wskaż aktualny milestone do realizacji
+- nic nie implementuj

--- a/.agents/skills/codex-flow-create-milestone-0-5/SKILL.md
+++ b/.agents/skills/codex-flow-create-milestone-0-5/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: codex-flow-create-milestone-0-5
+description: >
+  Użyj, gdy trzeba dodać do ROADMAP.md specjalny początkowy Milestone 0.5
+  opisujący minimalny end-to-end slice projektu. Ten skill aktualizuje tylko
+  ROADMAP.md i nie implementuje kodu. Nie używaj go do zwykłych kolejnych
+  milestone'ów ani do realizacji Milestone 0.5.
+---
+
+Dodaj do `ROADMAP.md` nowy milestone przed wszystkimi innymi:
+
+Milestone 0.5 — Minimal end-to-end slice
+
+Cel:
+- aplikacja uruchamia się
+- wykonuje jedno bardzo proste zadanie
+- zwraca poprawny wynik
+
+Definition of Done:
+- aplikację da się uruchomić jednym poleceniem
+- istnieje co najmniej jeden smoke test
+- testy przechodzą lokalnie
+- brak placeholderów
+
+Zapisz zmiany do `ROADMAP.md`.
+Nie zmieniaj kodu.

--- a/.agents/skills/codex-flow-finalize-and-push-change/SKILL.md
+++ b/.agents/skills/codex-flow-finalize-and-push-change/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: codex-flow-finalize-and-push-change
+description: >
+  Użyj po zakończeniu implementacji lub po wdrożeniu poprawek, gdy trzeba
+  domknąć zmianę operacyjnie: zaktualizować ROADMAP.md, STATUS.md, a w razie
+  potrzeby spec.md i README.md, następnie przygotować commit oraz wykonać push,
+  jeśli repo ma skonfigurowany remote i stan jest gotowy do zapisania. Nie
+  używaj do dodawania nowych funkcji ani planowania kolejnej pracy.
+---
+
+Domknij zmianę operacyjnie.
+
+Przebieg pracy:
+1. Sprawdź stan repo i zakres bieżącej zmiany.
+2. Zaktualizuj dokumentację operacyjną:
+   - `ROADMAP.md`
+   - `STATUS.md`
+   - `spec.md`, jeśli ostatnia praca zmieniła ustalenia lub decyzje techniczne
+   - `README.md`, jeśli ostatnia praca zmieniła sposób użycia, uruchamiania, wymagania lub ważne zachowania systemu
+3. Upewnij się, że dokumentacja odzwierciedla faktyczny stan repo.
+4. Zweryfikuj, czy working tree jest gotowe do zapisania.
+5. Przygotuj sensowny commit.
+6. Wykonaj push tylko wtedy, gdy repo ma poprawnie skonfigurowany remote i nie ma sygnałów, że należy zatrzymać zmianę lokalnie.
+
+Zasady:
+- nie dodawaj nowej implementacji
+- nie rozszerzaj zakresu pracy
+- nie aktualizuj `README.md` ani `spec.md` kosmetycznie; zmieniaj je tylko wtedy, gdy stan repo realnie tego wymaga
+- jeśli potrzebujesz doprecyzowania zasad aktualizacji dokumentacji lub commitowania, użyj plików z `references/`
+- jeśli potrzebujesz sprawdzić stan working tree lub wykonać walidację przed pushem, użyj skryptów z `scripts/`
+
+Wynik:
+- podsumuj, które pliki dokumentacyjne zostały zaktualizowane
+- podaj informację, czy wykonano commit
+- podaj informację, czy wykonano push, czy świadomie go pominięto

--- a/.agents/skills/codex-flow-finalize-and-push-change/references/COMMIT-RULES.md
+++ b/.agents/skills/codex-flow-finalize-and-push-change/references/COMMIT-RULES.md
@@ -1,0 +1,6 @@
+# Zasady commitowania
+
+- Grupuj zmiany tak, aby commit opisywał jedną logiczną zmianę.
+- Nie mieszaj nowej implementacji z przypadkowymi poprawkami pobocznymi.
+- Jeśli zmiany dokumentacyjne są integralną częścią wykonanej pracy, mogą wejść do tego samego commita.
+- Komunikat commita powinien jasno opisywać efekt zmiany, a nie sam fakt edycji plików.

--- a/.agents/skills/codex-flow-finalize-and-push-change/references/DOC-UPDATE-RULES.md
+++ b/.agents/skills/codex-flow-finalize-and-push-change/references/DOC-UPDATE-RULES.md
@@ -1,0 +1,18 @@
+# Zasady aktualizacji dokumentacji
+
+## ROADMAP.md
+Aktualizuj statusy milestone'ów zgodnie z faktycznym postępem.
+
+## STATUS.md
+Zapisz aktualny stan projektu, ograniczenia i istotne następne kroki.
+
+## spec.md
+Aktualizuj tylko wtedy, gdy wykonana praca zmieniła lub doprecyzowała decyzje techniczne albo zachowanie systemu.
+
+## README.md
+Aktualizuj tylko wtedy, gdy zmienił się:
+- sposób uruchamiania
+- wymagania
+- komendy developerskie
+- opis zachowania funkcji
+- ważne ograniczenia lub istotne zachowania systemu

--- a/.agents/skills/codex-flow-finalize-and-push-change/scripts/check-working-tree.sh
+++ b/.agents/skills/codex-flow-finalize-and-push-change/scripts/check-working-tree.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== git status --short =="
+git status --short || true
+
+echo
+if git remote -v >/dev/null 2>&1; then
+  echo "== git remote -v =="
+  git remote -v || true
+fi

--- a/.agents/skills/codex-flow-finalize-and-push-change/scripts/pre-push-verify.sh
+++ b/.agents/skills/codex-flow-finalize-and-push-change/scripts/pre-push-verify.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Uruchom przed pushem tylko te walidacje, które są standardem w repo."
+echo "Przykłady: testy, lint, typecheck, build, smoke tests."
+echo "Nie zgaduj komend; użyj tych z README, AGENTS.md lub konfiguracji projektu."

--- a/.agents/skills/codex-flow-generate-spec-from-prd/SKILL.md
+++ b/.agents/skills/codex-flow-generate-spec-from-prd/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: codex-flow-generate-spec-from-prd
+description: >
+  Użyj, gdy w projekcie pojawia się pierwszy lub główny PRD, na podstawie którego
+  trzeba wypełnić albo wygenerować zawartość spec.md i ROADMAP.md bez zmiany kodu.
+  Wejściem jest bazowy plik PRD w katalogu prd, a wyjściem są spójne aktualizacje
+  specyfikacji i roadmapy. Nie używaj tego skilla do kolejnych przyrostowych PRD,
+  które tylko rozszerzają istniejący plan.
+---
+
+Na podstawie pliku `prd/000-initial-prd.md`:
+
+## ETAP 0 --- Ocena zmiany
+
+0.1. Oceń zakres PRD: **MAŁY / ŚREDNI / DUŻY**  
+0.2. Oceń czy zawiera istotne ryzyka lub niejasności.  
+0.3. Nie zapisuj tej oceny do plików --- użyj jej wyłącznie do
+kalibracji roadmapy.
+
+---
+
+## ETAP 1 --- Specyfikacja
+
+1. Wypełnij istniejący plik `spec.md`, korzystając z jego OBECNEJ struktury.
+2. Nie zmieniaj nagłówków, nazw sekcji ani kolejności.
+3. Uzupełnij sekcje na poziomie wysokim (bez szczegółów implementacyjnych).
+4. Jeśli brakuje informacji, dodaj:
+
+    TODO: [KONKRETNE PYTANIE DO DOPRECYZOWANIA]
+
+5. Decyzje techniczne wpisuj wyłącznie do sekcji `## Decyzje techniczne` i tylko jeśli wynikają bezpośrednio z PRD.
+
+---
+
+## ETAP 2 --- Roadmapa
+
+6. Wypełnij istniejący plik `ROADMAP.md`, zachowując jego strukturę.
+7. Nie zmieniaj nazw sekcji ani dozwolonych statusów.
+8. Zachowaj Milestone 0.5 jako pierwszy element.
+9. Każdy milestone musi zawierać:
+   - Cel
+   - Definition of Done (mierzalne i testowalne)
+   - Zakres
+10. Jeśli zakres = DUŻY:
+- rozbij implementację na mniejsze milestone'y
+- dodaj milestone redukujący ryzyko (spike / walidacja)
+
+---
+
+## ETAP 3 --- Sprawdzenie spójności
+
+11. Sprawdź:
+- czy roadmapa wynika ze spec
+- czy nie ma sprzeczności
+- czy nie ma elementów w roadmapie, których nie ma w spec
+
+---
+
+## Zasady ogólne
+
+- Nie zmieniaj struktury plików.
+- Nie zmieniaj kodu.
+- Nie zgaduj brakujących informacji.
+- Generuj konkretne pytania zamiast domysłów.

--- a/.agents/skills/codex-flow-implement-milestone-0-5/SKILL.md
+++ b/.agents/skills/codex-flow-implement-milestone-0-5/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: codex-flow-implement-milestone-0-5
+description: >
+  Użyj, gdy trzeba zaimplementować wyłącznie specjalny Milestone 0.5 z ROADMAP.md:
+  minimalny działający end-to-end slice, uruchomienie aplikacji i smoke test.
+  Ten skill dotyczy tylko bootstrapowego etapu projektu. Nie używaj go do
+  późniejszych milestone'ów ani do samej aktualizacji roadmapy.
+---
+
+Zaimplementuj Milestone 0.5 dokładnie zgodnie z `ROADMAP.md`.
+
+Zasady:
+- minimalna ilość kodu
+- brak optymalizacji
+- brak refactorów niezwiązanych z milestone’em
+- jeśli coś jest niejasne:
+  - podejmij najprostszą decyzję
+  - opisz ją w `spec.md` w sekcji `## Decyzje techniczne`
+
+Po zakończeniu:
+- upewnij się, że aplikacja się uruchamia
+- uruchom testy
+- zrób commit z czytelnym opisem

--- a/.agents/skills/codex-flow-implement-milestone/SKILL.md
+++ b/.agents/skills/codex-flow-implement-milestone/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: codex-flow-implement-milestone
+description: >
+  Użyj, gdy trzeba zaimplementować jeden konkretny milestone z ROADMAP.md inny
+  niż Milestone 0.5. W poleceniu użytkownika należy wskazać identyfikator,
+  nazwę albo jasno określić, który milestone ma zostać zrealizowany. Ten skill
+  realizuje tylko zakres wskazanego milestone'u i nie służy do planowania,
+  tworzenia roadmapy ani finalizacji całej zmiany.
+---
+
+Zaimplementuj wskazany milestone z `ROADMAP.md`.
+
+Jeśli użytkownik nie podał jednoznacznie, który milestone ma być wdrożony:
+- wybierz pierwszy milestone ze statusem `planned` lub `in_progress`, który nie jest Milestone 0.5
+- krótko wskaż, który milestone został wybrany do realizacji
+
+Zasady:
+- realizuj wyłącznie zakres danego milestone’u
+- nie zmieniaj architektury bez wyraźnej potrzeby
+- jeśli zakres jest niejasny:
+  - najpierw doprecyzuj `ROADMAP.md` lub `spec.md`
+  - dopiero potem implementuj
+
+Po zakończeniu:
+- uruchom testy

--- a/.agents/skills/codex-flow-next-prd/SKILL.md
+++ b/.agents/skills/codex-flow-next-prd/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: codex-flow-next-prd
+description: >
+  Użyj, gdy w katalogu prd pojawia się kolejny przyrostowy PRD rozszerzający
+  istniejący projekt i trzeba zaktualizować spec.md oraz ROADMAP.md bez zmiany
+  kodu. W poleceniu użytkownika należy wskazać nazwę pliku PRD albo jednoznacznie
+  wskazać, którego nowego PRD dotyczy aktualizacja. Nie używaj tego skilla do
+  pierwszego bazowego PRD projektu.
+---
+
+Na podstawie wskazanego pliku `prd/<nazwa-pliku>.md`:
+
+## ETAP 0 --- Ocena zmiany
+
+0.1. Oceń zakres zmiany: **MAŁY / ŚREDNI / DUŻY**  
+0.2. Oceń czy wpływa na istniejące milestone'y.  
+0.3. Oceń czy istnieje potencjalny konflikt ze spec.  
+0.4. Nie zapisuj tej oceny do plików.
+
+---
+
+## ETAP 1 --- Aktualizacja specyfikacji
+
+1. Zaktualizuj `spec.md`, zachowując OBECNĄ strukturę.
+2. Nie zmieniaj nagłówków ani kolejności sekcji.
+3. Rozszerz tylko te sekcje, których dotyczy nowe PRD.
+4. Nie usuwaj wcześniejszych decyzji.
+5. Nowe decyzje techniczne dodaj do `## Decyzje techniczne` z oznaczeniem `(dotyczy PRD: nazwa-pliku)`.
+6. Jeśli pojawia się konflikt:
+   - opisz go w `## Decyzje techniczne`
+   - nie rozwiązuj go samodzielnie
+   - nie nadpisuj istniejących decyzji
+7. Jeśli brakuje informacji, dodaj:
+
+    TODO: [KONKRETNE PYTANIE DO DOPRECYZOWANIA]
+
+---
+
+## ETAP 2 --- Aktualizacja roadmapy
+
+8. Zaktualizuj `ROADMAP.md`.
+9. Nie zmieniaj istniejących milestone'ów ani ich statusów.
+10. Nowe milestone'y dodaj na końcu z kolejną numeracją.
+11. Każdy nowy milestone musi zawierać:
+
+- Cel
+- Definition of Done
+- Zakres
+
+12. Jeśli zakres = DUŻY:
+- podziel implementację na mniejsze kroki
+- dodaj milestone redukcji ryzyka
+
+---
+
+## ETAP 3 --- Spójność
+
+13. Sprawdź:
+- czy nowe milestone'y wynikają z aktualizacji spec
+- czy nie powstały sprzeczności
+- czy kolejność realizacji jest logiczna
+
+---
+
+## Zasady ogólne
+
+- Jeśli użytkownik nie podał jednoznacznie nazwy pliku, wybierz najnowszy lub najbardziej oczywisty nowy plik z katalogu `prd/` i wskaż go w odpowiedzi.
+- Nie zmieniaj struktury plików.
+- Nie zmieniaj kodu.
+- Nie zgaduj brakujących informacji.
+- Generuj konkretne pytania zamiast domysłów.

--- a/.agents/skills/codex-flow-project-wrap-up/SKILL.md
+++ b/.agents/skills/codex-flow-project-wrap-up/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: codex-flow-project-wrap-up
+description: >
+  Użyj, gdy kończysz sesję pracy nad projektem i chcesz uporządkować stan
+  dokumentacji operacyjnej bez implementacji nowych zmian: zaktualizować
+  ROADMAP.md, STATUS.md oraz w razie potrzeby README.md, a następnie upewnić
+  się, że bieżący stan jest zapisany w repo. Ten skill nie służy do wdrażania
+  funkcji ani do tworzenia nowego planu.
+---
+
+Zrób porządek w projekcie.
+
+Przebieg pracy:
+1. Zaktualizuj `ROADMAP.md`:
+   - statusy milestone'ów zgodnie z rzeczywistością
+2. Zaktualizuj `STATUS.md`:
+   - aktualny stan projektu
+   - istotne ograniczenia
+   - najbliższy sensowny następny krok, jeśli wynika z obecnego stanu
+3. Sprawdź `README.md` i zaktualizuj go tylko wtedy, gdy ostatnie zmiany wpływają na informacje istotne dla człowieka:
+   - sposób uruchamiania
+   - wymagania
+   - komendy developerskie
+   - opis działania funkcji
+   - ograniczenia lub ważne zachowania systemu
+4. Upewnij się, że stan repo jest zapisany:
+   - jeśli są niezapisane zmiany dokumentacyjne wynikające z wrap-up, przygotuj commit
+   - jeśli nie ma zmian, nie twórz pustych commitów
+
+Zasady:
+- nie zmieniaj kodu
+- nie aktualizuj `README.md` kosmetycznie ani bez realnej potrzeby
+- dokumentacja ma odzwierciedlać faktyczny stan repo
+- jeśli potrzebujesz doprecyzowania zasad wrap-up albo README, użyj plików z `references/`
+- jeśli potrzebujesz technicznie sprawdzić stan repo, użyj skryptów z `scripts/`
+
+Wynik:
+- podsumuj, które dokumenty zostały zaktualizowane
+- zaznacz, czy powstał commit dokumentacyjny
+- jeśli nic nie wymagało zmian, napisz to wprost

--- a/.agents/skills/codex-flow-project-wrap-up/references/README-RULES.md
+++ b/.agents/skills/codex-flow-project-wrap-up/references/README-RULES.md
@@ -1,0 +1,12 @@
+# Kiedy aktualizować README.md
+
+Aktualizuj README.md tylko wtedy, gdy ostatnie zmiany wpływają na informacje ważne dla człowieka korzystającego z repo.
+
+Przykłady:
+- zmienił się sposób uruchamiania
+- doszły nowe wymagania środowiskowe
+- zmieniły się komendy developerskie
+- zachowanie funkcji wymaga nowego opisu
+- pojawiły się ważne ograniczenia lub niestandardowe zachowania
+
+Nie aktualizuj README.md tylko po to, aby "coś dopisać" lub kosmetycznie przepisywać istniejący opis.

--- a/.agents/skills/codex-flow-project-wrap-up/references/WRAP-UP-CHECKLIST.md
+++ b/.agents/skills/codex-flow-project-wrap-up/references/WRAP-UP-CHECKLIST.md
@@ -1,0 +1,8 @@
+# Checklist końca sesji
+
+- Czy statusy milestone'ów są aktualne?
+- Czy STATUS.md opisuje faktyczny stan projektu?
+- Czy istnieją ważne ograniczenia, które powinny być zapisane?
+- Czy README.md wymaga aktualizacji po ostatnich zmianach?
+- Czy working tree jest czysty albo czy pozostałe zmiany są świadomie zostawione?
+- Czy trzeba zapisać dokumentacyjne zmiany w commicie?

--- a/.agents/skills/codex-flow-project-wrap-up/scripts/check-doc-sync.sh
+++ b/.agents/skills/codex-flow-project-wrap-up/scripts/check-doc-sync.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== git status --short =="
+git status --short || true
+
+echo
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "== recently changed files =="
+  git diff --name-only HEAD || true
+fi

--- a/.agents/skills/codex-flow-self-review/SKILL.md
+++ b/.agents/skills/codex-flow-self-review/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: codex-flow-self-review
+description: >
+  Użyj po zakończeniu implementacji, gdy trzeba wykonać przegląd własnych
+  ostatnich zmian pod kątem zgodności z ROADMAP.md, spec.md, AGENTS.md i
+  jakości kodu. Najpierw przeanalizuj zmienione pliki, dokumentację i wyniki
+  testów, a następnie przygotuj listę problemów oraz konkretnych poprawek.
+  Nie wdrażaj jeszcze zmian. Nie używaj do implementacji funkcji ani do
+  nanoszenia poprawek po review.
+---
+
+Wykonaj self-review ostatnich zmian.
+
+Cel:
+- sprawdzić spójność implementacji z dokumentacją projektu
+- wykryć niespójności, naruszenia zasad i ryzyka jakościowe
+- przygotować konkretną listę poprawek bez wprowadzania zmian w kodzie
+
+Przebieg pracy:
+1. Zidentyfikuj zakres ostatnich zmian:
+   - sprawdź zmienione pliki
+   - sprawdź, jaki milestone lub zadanie było realizowane
+   - sprawdź, czy uruchomiono odpowiednie testy lub walidacje
+2. Oceń zgodność z dokumentacją:
+   - `ROADMAP.md`
+   - `spec.md`
+   - `AGENTS.md`
+   - `README.md`, jeśli zmiany wpływają na sposób użycia lub uruchamiania
+3. Oceń jakość wykonania:
+   - poprawność rozwiązania
+   - prostotę implementacji
+   - duplikację logiki
+   - zbędne abstrakcje
+   - martwy kod
+   - pokrycie testami i sensowność testów
+4. Przygotuj wynik przeglądu.
+
+Zasady:
+- niczego jeszcze nie zmieniaj
+- nie rozszerzaj zakresu review poza ostatnie zmiany, chyba że wykryjesz realny wpływ uboczny
+- opieraj ocenę na faktycznym stanie repo i dokumentacji
+- jeśli potrzebujesz bardziej szczegółowej checklisty lub formatu wyniku, użyj plików z `references/`
+- jeśli potrzebujesz technicznego wsparcia do zebrania danych o zmianach lub uruchomienia walidacji, użyj skryptów z `scripts/`
+
+Wynik:
+- jeśli są problemy, wypisz je jasno i pogrupuj według ważności
+- do każdego problemu dopisz proponowaną poprawkę
+- jeśli wszystko jest poprawne, napisz dokładnie:
+  `Self-review zakończony – brak problemów krytycznych.`

--- a/.agents/skills/codex-flow-self-review/references/CHECKLIST.md
+++ b/.agents/skills/codex-flow-self-review/references/CHECKLIST.md
@@ -1,0 +1,33 @@
+# Checklist self-review
+
+## 1. Zgodność z ROADMAP.md
+- Czy zrealizowany zakres odpowiada aktualnemu milestone'owi?
+- Czy nie dodano funkcjonalności spoza zakresu?
+- Czy wynik odpowiada Definition of Done?
+
+## 2. Zgodność ze spec.md
+- Czy implementacja jest spójna z aktualną specyfikacją?
+- Czy nie złamano wcześniejszych decyzji technicznych?
+- Czy nowe zachowania są zgodne z opisanym kontraktem systemu?
+
+## 3. Zgodność z AGENTS.md
+- Czy zachowano zasady struktury repo?
+- Czy nie dodano zależności bez uzasadnienia?
+- Czy testy i sposób uruchamiania są zgodne z zasadami projektu?
+- Czy opis entrypointów i komend jest nadal prawidłowy?
+
+## 4. Jakość kodu
+- Czy implementacja jest możliwie prosta?
+- Czy nie ma zbędnych abstrakcji?
+- Czy nie ma duplikacji logiki?
+- Czy nie ma martwego kodu, nieużywanych helperów lub obejść tymczasowych bez komentarza?
+- Czy nazwy są czytelne i spójne?
+
+## 5. Testy i walidacja
+- Czy istnieją testy dla kluczowej ścieżki?
+- Czy testy sprawdzają właściwe zachowanie, a nie tylko przypadkowe szczegóły?
+- Czy uruchomiono odpowiednie komendy walidacyjne?
+
+## 6. Dokumentacja dla człowieka
+- Czy README.md wymaga aktualizacji?
+- Czy STATUS.md lub ROADMAP.md wymagają korekty po wykonanej pracy?

--- a/.agents/skills/codex-flow-self-review/references/OUTPUT-FORMAT.md
+++ b/.agents/skills/codex-flow-self-review/references/OUTPUT-FORMAT.md
@@ -1,0 +1,21 @@
+# Format wyniku self-review
+
+Użyj następującej struktury odpowiedzi:
+
+## Krytyczne
+- problem
+- dlaczego to problem
+- proponowana poprawka
+
+## Ważne
+- problem
+- dlaczego to problem
+- proponowana poprawka
+
+## Drobne
+- problem
+- dlaczego to problem
+- proponowana poprawka
+
+Jeśli brak problemów krytycznych, napisz dokładnie:
+`Self-review zakończony – brak problemów krytycznych.`

--- a/.agents/skills/codex-flow-self-review/scripts/collect-changed-files.sh
+++ b/.agents/skills/codex-flow-self-review/scripts/collect-changed-files.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== git status --short =="
+git status --short || true
+
+echo
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo "== changed files vs HEAD =="
+  git diff --name-only HEAD || true
+else
+  echo "== repository has no commits yet; listing tracked files =="
+  git ls-files || true
+fi

--- a/.agents/skills/codex-flow-self-review/scripts/run-review-checks.sh
+++ b/.agents/skills/codex-flow-self-review/scripts/run-review-checks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Uruchom tylko komendy walidacyjne, które faktycznie istnieją w tym repo."
+echo "Przykłady: testy, lint, typecheck, build, smoke tests."
+echo "Dostosuj ręcznie do projektu zamiast zgadywać nieistniejące komendy."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Run unit tests
+        run: uv run python -m unittest discover -s tests -p "test_*.py"
+
+      - name: Build check (compile)
+        run: uv run python -m compileall -q prompt_assistant main.py tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+Ten plik jest wyłącznie operacyjny: jak uruchamiać, testować i zarządzać zależnościami.
+Decyzje produktowe/architektura: `spec.md` / `ROADMAP.md` / `STATUS.md`.
+
+## Język
+- Komunikacja wyłącznie po polsku.
+
+## Środowisko i zależności
+- Używaj `uv` do zarządzania środowiskiem i zależnościami (nie twórz innych venv).
+- Dodawanie zależności: `uv add <pakiet>`.
+- Każda nowa zależność musi być uzasadniona w `spec.md` (sekcja „Decyzje techniczne”).
+
+## Uruchamianie
+- Preferuj uruchamianie przez `uv`:
+  - `uv run python -m <moduł_lub_pakiet>`
+- Alternatywnie (pojedynczy plik):
+  - `uv run <plik.py>`
+- Komenda uruchomienia musi być opisana w `README.md`.
+
+## Testy
+- Framework: `unittest`.
+- Uruchomienie:
+  - `uv run python -m unittest discover -s tests -p "test_*.py"`
+- Smoke testy: bez IO (sieć/API/dysk); używaj stubów/fake’ów.
+
+## Konwencje repo
+- Kod w `src/` (albo w root tylko dla małych projektów); testy w `tests/`.
+- Nie dodawaj dodatkowych `.py` do root’a, jeśli używasz struktury `src/`.
+- Jeden entrypoint, opisany w `README.md`.
+
+## Sekrety i konfiguracja
+- Nie przechowuj sekretów w repo.
+- Używaj zmiennych środowiskowych i dokumentuj je w `README.md`.
+- Bez domyślnych kluczy i fallbacków.
+
+## Styl
+- Indentacja: 4 spacje.
+- Nazwy: moduły/funkcje `snake_case`, klasy `PascalCase`.
+- Kod prosty, bez „magii”; komentarze tylko przy nieoczywistej logice.
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ## Opis
 PromptGlue to aplikacja umożliwiająca szybkie połącznie z promptu + załączonych plików w jeden blok tekstowy, dla modeli które aktualnie nie pozwalają dołączać plików. 
 
+Aktualnie aplikacja wspiera:
+- final preview outputu,
+- eksport do `.md` i `.txt`,
+- profile formatu outputu: XML-like, Markdown blocks, Plain text.
+
 ## Instalacja UV
 [UV](https://github.com/astral-sh/uv) - Ultra szybki manager paczek i projektów dla Python napisany w Rust
 ```bash
@@ -21,5 +26,4 @@ uv run main.py
 ```bash
 uv run python -m unittest discover -s tests -p "test_*.py"
 ```
-
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,62 @@
 # PromptGlue
 
 ## Opis
-PromptGlue to aplikacja umożliwiająca szybkie połącznie z promptu + załączonych plików w jeden blok tekstowy, dla modeli które aktualnie nie pozwalają dołączać plików. 
+PromptGlue to lokalne narzędzie desktopowe do składania jednego wejścia dla LLM z promptu i wielu plików.
 
 Aktualnie aplikacja wspiera:
 - final preview outputu,
 - eksport do `.md` i `.txt`,
-- profile formatu outputu: XML-like, Markdown blocks, Plain text.
+- profile formatu outputu: XML-like, Markdown blocks, Plain text,
+- filtrowanie listy plików (nazwa/rozszerzenie/status),
+- masowe akcje include/exclude/remove,
+- raport importu katalogu z przyczynami pominięć i błędami odczytu.
 
-## Instalacja UV
-[UV](https://github.com/astral-sh/uv) - Ultra szybki manager paczek i projektów dla Python napisany w Rust
+## Wymagania
+- Python 3.13+
+- `uv`
+
+Instalacja `uv` (macOS):
 ```bash
 brew install uv
 ```
 
-## Uruchomienie
-
-W katalogu z repozytorium:
+## Uruchomienie GUI
+W katalogu repozytorium:
 ```bash
 uv run main.py
 ```
 
-## Testy
+## Minimalny hook CLI
+Przykład użycia:
+```bash
+uv run python -m prompt_assistant.cli --prompt "Przeanalizuj" --format xml README.md spec.md
+```
 
+Zapis do pliku:
+```bash
+uv run python -m prompt_assistant.cli --prompt "Podsumuj" --format markdown --output wynik.md README.md
+```
+
+## Testy lokalne
 ```bash
 uv run python -m unittest discover -s tests -p "test_*.py"
 ```
 
+## Build check lokalny
+```bash
+uv run python -m compileall -q prompt_assistant main.py tests
+```
+
+## CI
+Repo zawiera workflow GitHub Actions: `.github/workflows/ci.yml`.
+CI uruchamia:
+- testy `unittest`,
+- check kompilacji (`compileall`).
+
+## Struktura repo (skrót)
+- `main.py` - entrypoint GUI
+- `prompt_assistant/gui/` - warstwa UI i kontrolery
+- `prompt_assistant/core/` - logika domenowa sesji/renderowania
+- `prompt_assistant/cli.py` - minimalny punkt zaczepienia pod CLI
+- `tests/` - testy jednostkowe
+- `spec.md`, `ROADMAP.md`, `STATUS.md` - dokumentacja projektu

--- a/README.md
+++ b/README.md
@@ -16,5 +16,10 @@ W katalogu z repozytorium:
 uv run main.py
 ```
 
+## Testy
+
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"
+```
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,7 @@ Uwagi:
 
 ---
 
-## Milestone 4: Fundament pod rozwój (planned)
+## Milestone 4: Fundament pod rozwój (done)
 
 Cel:
 - przygotować repo i proces pod dalszą ewolucję produktu
@@ -116,4 +116,4 @@ Zakres:
 - przygotowanie rozszerzalności core
 
 Uwagi:
-- odblokowany po stabilizacji funkcjonalnej i domknięciu M3
+- odblokowany po stabilizacji funkcjonalnej i domknięciu M3; zrealizowany

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@ Uwagi:
 
 ---
 
-## Milestone 3: Ergonomia i komunikacja błędów (blocked)
+## Milestone 3: Ergonomia i komunikacja błędów (done)
 
 Cel:
 - usprawnić pracę na większych zestawach plików
@@ -95,11 +95,11 @@ Zakres:
 - dopięcie testów scenariuszy UX
 
 Uwagi:
-- blocked do czasu domknięcia M1 i M2 oraz doprecyzowania UX dla masowych akcji
+- zrealizowano po domknięciu M1 i M2
 
 ---
 
-## Milestone 4: Fundament pod rozwój (blocked)
+## Milestone 4: Fundament pod rozwój (planned)
 
 Cel:
 - przygotować repo i proces pod dalszą ewolucję produktu
@@ -116,4 +116,4 @@ Zakres:
 - przygotowanie rozszerzalności core
 
 Uwagi:
-- blocked do czasu stabilizacji funkcjonalnej po M2
+- odblokowany po stabilizacji funkcjonalnej i domknięciu M3

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,119 @@
+# Roadmapa (milestones)
+
+## Statusy milestone'ów
+Dozwolone statusy:
+- planned
+- in_progress
+- done
+- blocked
+
+---
+
+## Milestone 0.5: Minimal end-to-end slice (done)
+
+Cel:
+- aplikacja uruchamia się
+- wykonuje jedno bardzo proste zadanie
+- zwraca poprawny wynik
+
+Definition of Done:
+- aplikację da się uruchomić jednym poleceniem (opisanym w README.md)
+- istnieje co najmniej jeden smoke test
+- testy przechodzą lokalnie
+- brak placeholderów w kodzie
+
+Zakres:
+- minimalny entrypoint aplikacji
+- minimalna logika domenowa
+- minimalna obsługa IO (jeśli dotyczy)
+- smoke test end-to-end
+
+---
+
+## Milestone 1: Spójny model sesji i renderer outputu (done)
+
+Cel:
+- usunąć ryzyko rozjazdu między listą wejść a finalnym promptem
+- wprowadzić jeden pipeline budowania outputu
+
+Definition of Done:
+- istnieje jawny model sesji jako źródło prawdy dla builda
+- usunięcie pliku usuwa jego blok z outputu
+- wykluczenie pliku usuwa jego blok z outputu
+- renderowanie finalnego outputu jest deterministyczne i testowalne bez GUI
+- testy jednostkowe dla krytycznych scenariuszy przechodzą lokalnie
+
+Zakres:
+- wydzielenie core/domain dla sesji i renderowania
+- integracja GUI z core dla akcji add/remove/exclude/copy
+- regresyjne testy remove/exclude/build
+
+Uwagi:
+- priorytet P0 z PRD (zaufanie i przewidywalność)
+
+---
+
+## Milestone 2: Preview finalnego outputu i eksport (planned)
+
+Cel:
+- zwiększyć kontrolę użytkownika nad końcowym wynikiem
+- zapewnić spójność preview, copy i export
+
+Definition of Done:
+- użytkownik może otworzyć final preview całego outputu
+- preview pokazuje ten sam wynik co copy
+- możliwy eksport do `.md` i `.txt`
+- dostępne są profile formatu outputu: plain text, markdown blocks, xml-like
+- testy jednostkowe dla renderer/profili i eksportu przechodzą lokalnie
+
+Zakres:
+- final preview dialog oparty o wspólny build pipeline
+- mechanizm eksportu i wybór formatu
+- rozszerzenie renderera o profile wyjścia
+
+Uwagi:
+- TODO: doprecyzować domyślny profil wyjścia dla copy/export
+
+---
+
+## Milestone 3: Ergonomia i komunikacja błędów (blocked)
+
+Cel:
+- usprawnić pracę na większych zestawach plików
+- podnieść transparentność działania
+
+Definition of Done:
+- dostępne filtrowanie listy plików (nazwa/rozszerzenie/status)
+- dostępne masowe akcje include/exclude/remove
+- raport importu katalogu zawiera przyczyny pominięć
+- błędy odczytu mają jawny status i powód
+- testy dla filtrów/masowych akcji/raportów przechodzą lokalnie
+
+Zakres:
+- komponent filtrów i masowych akcji
+- standaryzacja raportowania błędów i pominięć
+- dopięcie testów scenariuszy UX
+
+Uwagi:
+- blocked do czasu domknięcia M1 i M2 oraz doprecyzowania UX dla masowych akcji
+
+---
+
+## Milestone 4: Fundament pod rozwój (blocked)
+
+Cel:
+- przygotować repo i proces pod dalszą ewolucję produktu
+
+Definition of Done:
+- podstawowy CI uruchamia testy i kontrole jakości
+- README zawiera onboarding i aktualne komendy uruchamiania/testów
+- struktura repo oraz granice warstw są czytelne
+- istnieje minimalny punkt zaczepienia pod przyszłe CLI
+
+Zakres:
+- konfiguracja podstawowego CI
+- porządki developerskie i dokumentacyjne
+- przygotowanie rozszerzalności core
+
+Uwagi:
+- blocked do czasu stabilizacji funkcjonalnej po M2

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ Uwagi:
 
 ---
 
-## Milestone 2: Preview finalnego outputu i eksport (planned)
+## Milestone 2: Preview finalnego outputu i eksport (done)
 
 Cel:
 - zwiększyć kontrolę użytkownika nad końcowym wynikiem

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,28 @@
+# Aktualny stan projektu
+
+## Co działa
+- Aplikacja GUI uruchamia się przez `uv run main.py`.
+- Załączanie plików i katalogów, wykluczanie/usuwanie oraz kopiowanie finalnego outputu.
+- Budowanie outputu działa przez warstwę `core` i stan `Session` jako źródło prawdy.
+
+## Co jest skończone
+- Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
+- Milestone 0.5 oznaczony jako `done`.
+- Milestone 1 oznaczony jako `done`:
+  - wydzielono warstwę `prompt_assistant/core`,
+  - GUI zintegrowano z modelem sesji,
+  - dodano testy regresyjne remove/exclude/build.
+
+## Co jest w trakcie
+- Milestone 2: preview finalnego outputu i eksport.
+
+## Co jest następne
+- Dodać final preview oparte o wspólny pipeline renderowania.
+- Dodać eksport do `.md` i `.txt`.
+- Dodać profile outputu: plain, markdown, xml-like.
+
+## Blokery i ryzyka
+- Brak doprecyzowanego domyślnego profilu outputu dla copy/export (TODO w roadmapie/spec).
+
+## Ostatnie aktualizacje
+- 2026-04-01: zakończono Milestone 1 i uruchomiono testy `unittest` (OK).

--- a/STATUS.md
+++ b/STATUS.md
@@ -10,6 +10,8 @@
 - Filtrowanie listy plików po nazwie, rozszerzeniu i statusie.
 - Masowe akcje na zaznaczonych elementach: include/exclude/remove.
 - Raport importu katalogu zawierający przyczyny pominięć i błędy odczytu.
+- Minimalny hook CLI oparty o warstwę `core`.
+- CI (GitHub Actions) uruchamia testy i check kompilacji.
 
 ## Co jest skończone
 - Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
@@ -17,17 +19,16 @@
 - Milestone 1 oznaczony jako `done`.
 - Milestone 2 oznaczony jako `done`.
 - Milestone 3 oznaczony jako `done`.
+- Milestone 4 oznaczony jako `done`.
 
 ## Co jest w trakcie
-- Milestone 4: Fundament pod rozwój.
+- Brak aktywnego milestone'u.
 
 ## Co jest następne
-- Dodać podstawowy CI (testy + build check).
-- Dopić onboarding i strukturę repo w README.
-- Dodać minimalny punkt zaczepienia pod CLI.
+- Roadmapa gotowa na kolejny PRD lub nowy milestone funkcjonalny.
 
 ## Blokery i ryzyka
-- Brak aktywnych blockerów dla M4.
+- Brak aktywnych blockerów.
 
 ## Ostatnie aktualizacje
-- 2026-04-01: zakończono M1, M2 i M3; testy `unittest` przechodzą lokalnie.
+- 2026-04-01: zakończono M1, M2, M3 i M4; testy `unittest` przechodzą lokalnie.

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,7 @@
 - Minimalny hook CLI oparty o warstwę `core`.
 - CI (GitHub Actions) uruchamia testy i check kompilacji.
 - Dolny obszar akcji GUI jest rozdzielony na osobne wiersze (input/output/bulk), co poprawia czytelność przy długich toolbarach.
+- Wykluczanie/usuwanie plików z importu katalogu aktualizuje również sekcję `<directories>` (drzewo zawiera tylko aktywne pliki).
 
 ## Co jest skończone
 - Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
@@ -34,3 +35,4 @@
 ## Ostatnie aktualizacje
 - 2026-04-01: zakończono M1, M2, M3 i M4; testy `unittest` przechodzą lokalnie.
 - 2026-04-02: poprawiono ergonomię layoutu GUI przez rozdzielenie przycisków na kilka pasków akcji.
+- 2026-04-02: naprawiono niespójność `<directories>` przy exclude/remove oraz dodano test regresyjny.

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,7 @@
 - Raport importu katalogu zawierający przyczyny pominięć i błędy odczytu.
 - Minimalny hook CLI oparty o warstwę `core`.
 - CI (GitHub Actions) uruchamia testy i check kompilacji.
+- Dolny obszar akcji GUI jest rozdzielony na osobne wiersze (input/output/bulk), co poprawia czytelność przy długich toolbarach.
 
 ## Co jest skończone
 - Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
@@ -32,3 +33,4 @@
 
 ## Ostatnie aktualizacje
 - 2026-04-01: zakończono M1, M2, M3 i M4; testy `unittest` przechodzą lokalnie.
+- 2026-04-02: poprawiono ergonomię layoutu GUI przez rozdzielenie przycisków na kilka pasków akcji.

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,28 +7,27 @@
 - Final preview pokazuje dokładnie ten sam output, który trafia do kopiowania i eksportu.
 - Eksport wyniku do `.md` i `.txt`.
 - Profile outputu: XML-like, Markdown blocks, Plain text.
+- Filtrowanie listy plików po nazwie, rozszerzeniu i statusie.
+- Masowe akcje na zaznaczonych elementach: include/exclude/remove.
+- Raport importu katalogu zawierający przyczyny pominięć i błędy odczytu.
 
 ## Co jest skończone
 - Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
 - Milestone 0.5 oznaczony jako `done`.
-- Milestone 1 oznaczony jako `done`:
-  - wydzielono warstwę `prompt_assistant/core`,
-  - GUI zintegrowano z modelem sesji,
-  - dodano testy regresyjne remove/exclude/build.
-- Milestone 2 oznaczony jako `done`:
-  - dodano final preview oparte o wspólny pipeline renderowania,
-  - dodano eksport do `.md` i `.txt`,
-  - dodano profile formatu outputu,
-  - rozszerzono testy o profile renderera i eksport.
+- Milestone 1 oznaczony jako `done`.
+- Milestone 2 oznaczony jako `done`.
+- Milestone 3 oznaczony jako `done`.
 
 ## Co jest w trakcie
-- Brak aktywnego milestone'u.
+- Milestone 4: Fundament pod rozwój.
 
 ## Co jest następne
-- Odblokować Milestone 3 po doprecyzowaniu UX dla filtrów i masowych akcji.
+- Dodać podstawowy CI (testy + build check).
+- Dopić onboarding i strukturę repo w README.
+- Dodać minimalny punkt zaczepienia pod CLI.
 
 ## Blokery i ryzyka
-- Milestone 3 i 4 pozostają `blocked` zgodnie z roadmapą.
+- Brak aktywnych blockerów dla M4.
 
 ## Ostatnie aktualizacje
-- 2026-04-01: zakończono Milestone 1 i Milestone 2; testy `unittest` przechodzą lokalnie.
+- 2026-04-01: zakończono M1, M2 i M3; testy `unittest` przechodzą lokalnie.

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,9 @@
 - Aplikacja GUI uruchamia się przez `uv run main.py`.
 - Załączanie plików i katalogów, wykluczanie/usuwanie oraz kopiowanie finalnego outputu.
 - Budowanie outputu działa przez warstwę `core` i stan `Session` jako źródło prawdy.
+- Final preview pokazuje dokładnie ten sam output, który trafia do kopiowania i eksportu.
+- Eksport wyniku do `.md` i `.txt`.
+- Profile outputu: XML-like, Markdown blocks, Plain text.
 
 ## Co jest skończone
 - Wygenerowano `spec.md` i `ROADMAP.md` na podstawie `prd/000-initial-prd.md`.
@@ -12,17 +15,20 @@
   - wydzielono warstwę `prompt_assistant/core`,
   - GUI zintegrowano z modelem sesji,
   - dodano testy regresyjne remove/exclude/build.
+- Milestone 2 oznaczony jako `done`:
+  - dodano final preview oparte o wspólny pipeline renderowania,
+  - dodano eksport do `.md` i `.txt`,
+  - dodano profile formatu outputu,
+  - rozszerzono testy o profile renderera i eksport.
 
 ## Co jest w trakcie
-- Milestone 2: preview finalnego outputu i eksport.
+- Brak aktywnego milestone'u.
 
 ## Co jest następne
-- Dodać final preview oparte o wspólny pipeline renderowania.
-- Dodać eksport do `.md` i `.txt`.
-- Dodać profile outputu: plain, markdown, xml-like.
+- Odblokować Milestone 3 po doprecyzowaniu UX dla filtrów i masowych akcji.
 
 ## Blokery i ryzyka
-- Brak doprecyzowanego domyślnego profilu outputu dla copy/export (TODO w roadmapie/spec).
+- Milestone 3 i 4 pozostają `blocked` zgodnie z roadmapą.
 
 ## Ostatnie aktualizacje
-- 2026-04-01: zakończono Milestone 1 i uruchomiono testy `unittest` (OK).
+- 2026-04-01: zakończono Milestone 1 i Milestone 2; testy `unittest` przechodzą lokalnie.

--- a/prd/000-initial-prd.md
+++ b/prd/000-initial-prd.md
@@ -1,0 +1,661 @@
+# PRD — PromptGlue v2
+
+## 1. Informacje podstawowe
+
+**Nazwa produktu:** PromptGlue v2  
+**Typ produktu:** desktop utility / local-first productivity tool for LAG (LLM-assisted generation)  
+**Docelowa platforma:** desktop (macOS / Windows / Linux)  
+**Status dokumentu:** propozycja PRD v1  
+**Właściciel produktu:** Growdelan  
+**Cel dokumentu:** zdefiniowanie kierunku rozwoju PromptGlue v2 tak, aby aplikacja była bardziej użyteczna, przewidywalna, łatwiejsza w utrzymaniu i gotowa do dalszej rozbudowy.
+
+---
+
+## 2. Streszczenie produktu
+
+PromptGlue to narzędzie, które skleja prompt użytkownika i zawartość wybranych plików lub katalogów do jednego tekstu wejściowego dla modeli LLM. Produkt rozwiązuje realny problem użytkowników, którzy pracują z modelami lub interfejsami nieobsługującymi wygodnie wielu plików, chcą kontrolować liczbę tokenów albo przygotować jeden gotowy blok wejściowy do wklejenia.
+
+Wersja v2 ma przekształcić PromptGlue z prostego utility w bardziej dopracowane narzędzie do pracy z kontekstem dla modeli AI. Najważniejsze cele tej wersji to:
+- poprawa przewidywalności działania,
+- usunięcie błędów w zarządzaniu zawartością promptu,
+- lepsza kontrola nad tym, co trafia do finalnego outputu,
+- poprawa ergonomii pracy na większej liczbie plików,
+- stworzenie fundamentu pod CLI i dalszą automatyzację.
+
+---
+
+## 3. Problem do rozwiązania
+
+Użytkownik chce szybko przygotować jeden końcowy prompt zawierający:
+- instrukcję,
+- kontekst z plików,
+- wybrane fragmenty kodu / dokumentów,
+- kontrolę nad rozmiarem wejścia.
+
+Obecne ograniczenia:
+1. Aplikacja jest przydatna, ale ma jeszcze poziom MVP.
+2. Praca na większym katalogu staje się mniej wygodna.
+3. Brakuje mocniejszej kontroli nad finalnym wynikiem.
+4. Istnieje krytyczny problem spójności:  
+   **po załadowaniu katalogu i usuwaniu poszczególnych plików, odpowiadające im bloki nie znikają z finalnego promptu**.  
+   To powoduje rozjazd między tym, co użytkownik widzi jako „załączone”, a tym, co faktycznie trafia do wyniku.
+
+Ten ostatni punkt jest kluczowy, bo uderza w zaufanie do produktu.
+
+---
+
+## 4. Wizja v2
+
+PromptGlue v2 ma być:
+- **local-first**,
+- **przewidywalny**,
+- **transparentny**,
+- **szybki w obsłudze**,
+- **dobry zarówno dla pojedynczego promptu, jak i pracy na całym repozytorium**.
+
+Wersja v2 nie ma być jeszcze pełną platformą do zarządzania kontekstem dla AI. Ma być bardzo dobrym, niezawodnym narzędziem do:
+- ładowania plików,
+- selekcji kontekstu,
+- usuwania / wykluczania treści,
+- podglądu końcowego wyniku,
+- eksportu do formatów przydatnych w pracy z LLM.
+
+---
+
+## 5. Cele biznesowe i produktowe
+
+### Cele główne
+1. Zwiększyć zaufanie do działania aplikacji.
+2. Zmniejszyć liczbę błędów użytkownika przy budowie promptu.
+3. Poprawić wygodę pracy na większej liczbie plików.
+4. Ułatwić rozwój produktu w kolejnych wersjach.
+5. Przygotować architekturę pod przyszłe CLI i workflow z agentami AI.
+
+### Mierniki sukcesu
+- 0 znanych przypadków rozjazdu między listą plików a finalnym promptem.
+- Skrócenie czasu przygotowania promptu z wielu plików.
+- Mniejsza liczba ręcznych korekt po skopiowaniu promptu.
+- Możliwość bezpiecznego rozwijania aplikacji dzięki wydzieleniu core od GUI.
+- Dodanie co najmniej 3 nowych funkcji zwiększających użyteczność bez pogorszenia prostoty.
+
+---
+
+## 6. Grupa docelowa
+
+### Segment podstawowy
+- developerzy,
+- DevOps / Cloud engineers,
+- osoby pracujące z repozytoriami i kodem,
+- użytkownicy LLM, którzy chcą ręcznie kontrolować kontekst.
+
+### Segment wtórny
+- PM / analitycy kopiujący dokumenty do modeli,
+- technical writers,
+- konsultanci przygotowujący duże prompty z wielu źródeł,
+- osoby robiące code review z pomocą AI.
+
+---
+
+## 7. Najważniejsze przypadki użycia
+
+1. **Załaduj katalog projektu i zbuduj prompt do analizy repozytorium.**
+2. **Dodaj kilka plików konfiguracyjnych i instrukcję, a potem skopiuj finalny prompt.**
+3. **Załaduj katalog, wyklucz część plików i wygeneruj mniejszy, czystszy kontekst.**
+4. **Przejrzyj podgląd końcowego outputu przed skopiowaniem.**
+5. **Wyeksportuj wynik do pliku `.md` lub `.txt`.**
+6. **Pracuj iteracyjnie: dodawaj/usuwaj pliki i miej pewność, że wynik zawsze odzwierciedla aktualny stan.**
+
+---
+
+## 8. Najważniejsze problemy obecnej wersji
+
+### 8.1 Problem krytyczny — niespójność przy usuwaniu plików
+Po załadowaniu katalogu usunięcie pliku z listy nie usuwa odpowiadającego mu bloku z finalnego promptu.
+
+### Dlaczego to jest krytyczne
+- użytkownik traci zaufanie do narzędzia,
+- może przypadkiem wysłać do modelu niechciane dane,
+- wynik jest nieprzewidywalny,
+- UI pokazuje inny stan niż rzeczywisty output.
+
+### Wniosek produktowy
+W v2 finalny prompt **musi być zawsze renderowany ze stanu źródłowego**, a nie aktualizowany „doklejaniem” lub częściowym mutowaniem tekstu wynikowego.
+
+---
+
+## 9. Zakres v2
+
+### In scope
+- przebudowa modelu danych,
+- poprawa logiki generowania outputu,
+- przewidywalne usuwanie plików,
+- final preview,
+- eksport,
+- lepsze zarządzanie listą plików,
+- lepsze komunikaty błędów,
+- przygotowanie pod CLI/core.
+
+### Out of scope
+- chmura / synchronizacja online,
+- multi-user collaboration,
+- wbudowane połączenia z API LLM,
+- zaawansowane AI features typu automatyczny summarization pipeline,
+- pełna wersja webowa.
+
+---
+
+## 10. Wymagania produktowe
+
+## 10.1 Zarządzanie wejściem
+
+### Funkcja: dodawanie plików
+Użytkownik może dodać pojedyncze pliki do sesji.
+
+**Wymagania:**
+- pliki pojawiają się na liście wejść,
+- każdy plik ma status: aktywny / wykluczony / błąd odczytu,
+- użytkownik widzi ścieżkę, rozmiar i typ,
+- pliki binarne są oznaczane i domyślnie pomijane.
+
+### Funkcja: dodawanie katalogu
+Użytkownik może dodać cały katalog.
+
+**Wymagania:**
+- rekursywne skanowanie,
+- respektowanie `.gitignore`,
+- własne wzorce wykluczeń,
+- pomijanie `.git`,
+- zabezpieczenie przed zbyt dużym wejściem,
+- raport: ile plików dodano, ile pominięto, dlaczego.
+
+---
+
+## 10.2 Zarządzanie listą plików
+
+### Funkcja: usuwanie pliku
+Użytkownik może usunąć plik z sesji.
+
+**Krytyczne wymaganie:**
+- po usunięciu pliku z listy odpowiadający blok **musi zniknąć z finalnego promptu**.
+
+### Funkcja: wykluczanie bez usuwania
+Użytkownik może oznaczyć plik jako „nie uwzględniaj w wyniku”, ale zostawić go na liście.
+
+**Wymagania:**
+- plik pozostaje widoczny,
+- nie trafia do finalnego outputu,
+- status jest czytelny w UI,
+- liczniki tokenów uwzględniają tylko aktywne pliki.
+
+### Funkcja: masowe akcje
+- zaznacz wiele plików,
+- usuń zaznaczone,
+- wyklucz zaznaczone,
+- przywróć zaznaczone,
+- filtruj po nazwie / rozszerzeniu / statusie.
+
+---
+
+## 10.3 Budowa finalnego promptu
+
+### Główna zasada architektoniczna
+Finalny prompt ma być **renderowany od zera** na podstawie aktualnego modelu sesji:
+- instrukcja użytkownika,
+- aktywne pliki,
+- kolejność plików,
+- ustawienia formatowania.
+
+### Zabronione podejście
+- ręczne „doklejanie” bloków do tekstu wynikowego,
+- częściowa mutacja wcześniej wygenerowanego outputu,
+- przechowywanie finalnego promptu jako źródła prawdy.
+
+### Wymagania
+- wynik zawsze odzwierciedla aktualny stan sesji,
+- po każdej zmianie możliwe jest odświeżenie preview,
+- kolejność bloków jest deterministyczna,
+- format jest spójny.
+
+---
+
+## 10.4 Preview finalnego outputu
+
+### Funkcja: final preview
+Użytkownik może otworzyć podgląd całego wygenerowanego promptu przed kopiowaniem lub eksportem.
+
+**Wymagania:**
+- pełny tekst końcowy,
+- możliwość szybkiego wyszukania fragmentu,
+- widoczna liczba tokenów,
+- możliwość kopiowania z preview,
+- możliwość eksportu z preview.
+
+### Wartość
+- większe zaufanie,
+- łatwiejsza kontrola jakości,
+- szybsze wykrywanie niechcianych fragmentów.
+
+---
+
+## 10.5 Tokeny i limity
+
+### Funkcja: token accounting
+System pokazuje:
+- tokeny promptu użytkownika,
+- tokeny per plik,
+- sumę końcową,
+- progi ostrzegawcze.
+
+**Wymagania:**
+- liczenie tylko dla aktywnych elementów,
+- szybka aktualizacja po każdej zmianie,
+- osobny widok breakdownu,
+- ostrzeżenia przy przekroczeniu progów.
+
+### Usprawnienie v2
+- cache tokenów per plik,
+- przeliczanie tylko dla zmienionych elementów,
+- osobne przeliczenie końcowe dla aktywnej sesji.
+
+---
+
+## 10.6 Eksport i formaty wyjścia
+
+### Funkcja: kopiowanie
+Użytkownik może skopiować finalny prompt do schowka.
+
+### Funkcja: eksport do pliku
+Użytkownik może zapisać wynik do:
+- `.md`,
+- `.txt`.
+
+### Funkcja: profile formatu
+Co najmniej 3 profile:
+1. Plain text
+2. Markdown blocks
+3. XML-like / structured context
+
+**Cel:** lepiej dopasować output do różnych modeli i stylów pracy.
+
+---
+
+## 10.7 Błędy i komunikacja
+
+### Wymagania
+- brak cichego ignorowania błędów,
+- każdy nieczytelny plik powinien mieć status i powód,
+- użytkownik powinien wiedzieć:
+  - czego nie dodano,
+  - co pominięto,
+  - dlaczego.
+
+### Minimalny standard
+- toast / dialog / status bar z informacją,
+- raport po wczytaniu katalogu,
+- logika błędów odseparowana od GUI.
+
+---
+
+## 11. Wymagania UX
+
+### Zasady
+- prostota,
+- przewidywalność,
+- minimum ukrytej magii,
+- UI ma odzwierciedlać rzeczywisty stan danych.
+
+### Główne elementy ekranu v2
+1. Pole na instrukcję / prompt użytkownika
+2. Panel listy plików
+3. Panel szczegółów / preview pliku
+4. Pasek akcji
+5. Pasek statusu z tokenami i liczbą aktywnych plików
+
+### Usprawnienia UX
+- wyszukiwarka po liście plików,
+- sortowanie,
+- szybkie filtry:
+  - wszystkie,
+  - aktywne,
+  - wykluczone,
+  - błędy,
+- czytelne badge statusów,
+- kontekstowe akcje pod prawym przyciskiem.
+
+---
+
+## 12. Wymagania techniczne
+
+## 12.1 Nowa architektura logiczna
+
+W v2 należy oddzielić GUI od logiki produktu.
+
+### Proponowane warstwy
+1. **UI layer**
+   - PyQt
+   - tylko prezentacja i event handling
+
+2. **Application layer**
+   - operacje na sesji
+   - use case’y: add files, remove files, exclude, build output, export
+
+3. **Domain / Core layer**
+   - model danych sesji,
+   - renderer finalnego promptu,
+   - ignore engine,
+   - token service,
+   - file ingestion rules
+
+4. **Infrastructure layer**
+   - filesystem,
+   - clipboard,
+   - export,
+   - config storage
+
+---
+
+## 12.2 Model danych
+
+### Encje
+#### Session
+- prompt_text
+- list of entries
+- output_format
+- settings
+- derived metadata
+
+#### Entry
+- id
+- path
+- source_type (file / dir import)
+- content
+- status
+- include_in_output (bool)
+- token_count
+- read_error
+- is_binary
+- size
+- last_loaded_at
+
+#### BuildResult
+- rendered_output
+- total_tokens
+- included_entries
+- excluded_entries
+- warnings
+- errors
+
+### Ważna zasada
+`BuildResult` jest wynikiem renderowania, a nie źródłem prawdy.  
+Źródłem prawdy jest `Session`.
+
+---
+
+## 12.3 Logika usuwania plików — wymaganie krytyczne
+
+### Stan docelowy
+Usunięcie pliku:
+- usuwa `Entry` z `Session.entries`,
+- invaliduje cache builda,
+- invaliduje cache tokenów zależnych od sesji,
+- po kolejnym buildzie plik nie istnieje w wyniku.
+
+### Kryterium akceptacji
+Jeżeli użytkownik:
+1. załaduje katalog z 20 plikami,
+2. usunie 3 z nich,
+3. otworzy final preview,
+
+to w preview i kopiowanym outputcie nie może być żadnego bloku odpowiadającego tym 3 plikom.
+
+### Regresja do uniknięcia
+Nie może istnieć sytuacja, w której:
+- lista plików pokazuje A, B, C,
+- a output dalej zawiera A, B, C, D.
+
+---
+
+## 12.4 Testowalność
+
+W v2 należy dodać testy dla:
+- renderowania finalnego outputu,
+- usuwania plików z sesji,
+- exclude/include,
+- `.gitignore`,
+- custom exclude patterns,
+- wykrywania binarek,
+- liczenia tokenów,
+- eksportu.
+
+### Test obowiązkowy
+**Po dodaniu katalogu i usunięciu pliku jego blok nie może występować w wynikowym promptcie.**
+
+---
+
+## 12.5 Wydajność
+
+### Oczekiwania
+- UI nie może się zacinać przy większym katalogu,
+- odczyt plików powinien być raportowany,
+- build outputu powinien być szybki,
+- tokeny powinny być cache’owane.
+
+### Działania
+- cache tokenów per entry,
+- lazy preview dla dużych plików,
+- odświeżenie builda tylko po zmianach,
+- opcjonalnie background worker do cięższych operacji.
+
+---
+
+## 12.6 Konfiguracja i developer experience
+
+### Wymagania
+- czytelna struktura repo,
+- prosty entrypoint,
+- sensowny `pyproject.toml`,
+- jasna instrukcja uruchamiania,
+- spójne wersjonowanie,
+- podstawowy CI:
+  - testy,
+  - lint,
+  - build check.
+
+---
+
+## 13. Wymagania niefunkcjonalne
+
+### Niezawodność
+- brak rozjazdu między UI i outputem,
+- brak cichego gubienia plików,
+- czytelne błędy.
+
+### Utrzymanie
+- rozdzielenie warstw,
+- testowalne core,
+- ograniczenie logiki w kontrolerach GUI.
+
+### Bezpieczeństwo
+- aplikacja lokalna,
+- bez obowiązkowych zewnętrznych połączeń,
+- ostrożne obchodzenie się z dużymi / binarnymi plikami.
+
+### Skalowalność produktu
+- gotowość do dodania CLI,
+- możliwość przyszłego reuse core w wersji terminalowej lub webowej.
+
+---
+
+## 14. User stories
+
+### US-01
+Jako użytkownik chcę dodać katalog projektu, aby szybko zbudować kontekst dla LLM.
+
+### US-02
+Jako użytkownik chcę usunąć wybrane pliki z listy i mieć pewność, że ich treść zniknie też z finalnego promptu.
+
+### US-03
+Jako użytkownik chcę wykluczyć plik bez usuwania go z listy, aby testować różne warianty promptu.
+
+### US-04
+Jako użytkownik chcę zobaczyć finalny output przed kopiowaniem, aby uniknąć pomyłek.
+
+### US-05
+Jako użytkownik chcę wyeksportować wynik do pliku, aby użyć go później lub przekazać dalej.
+
+### US-06
+Jako użytkownik chcę widzieć tokeny tylko dla aktywnych elementów, aby świadomie zarządzać limitem kontekstu.
+
+### US-07
+Jako developer chcę mieć wydzielony core, aby łatwo testować logikę i rozwijać CLI.
+
+---
+
+## 15. Kryteria akceptacji
+
+## 15.1 Kryteria obowiązkowe
+1. Po usunięciu pliku z sesji jego blok nie występuje w finalnym promptcie.
+2. Po wykluczeniu pliku z sesji jego blok nie występuje w finalnym promptcie.
+3. Final preview pokazuje dokładnie to samo, co trafia do schowka i eksportu.
+4. Licznik tokenów odpowiada tylko aktywnym elementom.
+5. Błędy odczytu są jawnie raportowane.
+6. Wczytanie katalogu pokazuje raport z plikami dodanymi i pominiętymi.
+7. Logika budowy outputu działa niezależnie od GUI.
+
+## 15.2 Kryteria jakościowe
+1. Kod core ma testy jednostkowe.
+2. Repo ma podstawowy CI.
+3. README zawiera realny onboarding.
+4. Struktura projektu jest czytelna dla nowego developera.
+
+---
+
+## 16. Priorytety funkcji
+
+### P0 — must have
+- naprawa usuwania bloków z outputu,
+- renderowanie outputu ze stanu sesji,
+- final preview,
+- poprawne include/exclude,
+- czytelne błędy,
+- podstawowe testy.
+
+### P1 — should have
+- eksport do `.md` i `.txt`,
+- wyszukiwarka po liście plików,
+- masowe akcje,
+- cache tokenów,
+- raport z importu katalogu.
+
+### P2 — nice to have
+- profile outputu,
+- drag & drop,
+- preset pod konkretne workflow,
+- CLI,
+- zapis / odczyt sesji.
+
+---
+
+## 17. Proponowana roadmapa implementacyjna
+
+## Faza 1 — stabilność i zaufanie
+Cel: naprawić podstawy.
+- wprowadzić `Session` jako source of truth,
+- przebudować build outputu,
+- naprawić usuwanie / exclude,
+- dodać testy regresyjne,
+- dodać final preview.
+
+## Faza 2 — ergonomia
+Cel: ułatwić pracę.
+- wyszukiwarka i filtrowanie,
+- masowe akcje,
+- eksport,
+- raporty i lepsze komunikaty.
+
+## Faza 3 — fundament pod rozwój
+Cel: umożliwić dalszą ewolucję.
+- wydzielony core,
+- CI,
+- CLI,
+- możliwość serializacji sesji.
+
+---
+
+## 18. Ryzyka
+
+1. **Ryzyko regresji przy przebudowie logiki builda**  
+   Mitigacja: testy snapshotowe outputu.
+
+2. **Ryzyko przekombinowania UI**  
+   Mitigacja: v2 ma pozostać prostym desktop utility.
+
+3. **Ryzyko utrzymania starej logiki równolegle z nową**  
+   Mitigacja: jeden spójny model danych i jeden renderer.
+
+4. **Ryzyko spadku wydajności po każdej zmianie stanu**  
+   Mitigacja: cache tokenów i lekki build pipeline.
+
+---
+
+## 19. Decyzje technologiczne
+
+### Obecny stack
+Python + PyQt pozostaje sensownym wyborem dla v2.
+
+### Rekomendacja
+Nie robić pełnego rewrite'u na tym etapie.
+
+### Co warto zrobić zamiast rewrite'u
+- rozdzielić core od GUI,
+- zaprojektować architekturę pod późniejsze CLI,
+- dopiero potem ocenić, czy część core / CLI ma sens przenieść np. do Go.
+
+### Kiedy Go zaczyna mieć sens
+- gdy pojawi się osobne CLI,
+- gdy liczy się prosty single-binary deployment,
+- gdy narzędzie ma być używane szeroko w terminalu i automatyzacjach,
+- gdy wydajność I/O i concurrency staną się realnym bottleneckiem.
+
+---
+
+## 20. Plan wdrożenia na 30 dni
+
+### Tydzień 1
+- zaprojektować `Session`, `Entry`, `BuildResult`,
+- wydzielić renderer finalnego promptu,
+- przygotować test regresyjny dla buga z usuwaniem plików.
+
+### Tydzień 2
+- wdrożyć nowy flow add/remove/exclude,
+- dopiąć final preview,
+- poprawić liczenie tokenów dla aktywnego stanu.
+
+### Tydzień 3
+- dodać eksport,
+- dodać raport ładowania katalogu,
+- dodać wyszukiwarkę i filtry listy plików.
+
+### Tydzień 4
+- uporządkować repo,
+- dodać CI i testy,
+- poprawić README,
+- przygotować bazę pod CLI.
+
+---
+
+## 21. Definicja sukcesu v2
+
+PromptGlue v2 będzie sukcesem, jeśli:
+- użytkownik ufa, że to co widzi w aplikacji jest dokładnie tym, co trafia do outputu,
+- usuwanie i wykluczanie działa bezbłędnie,
+- praca na katalogach jest wygodniejsza,
+- produkt pozostaje prosty,
+- architektura pozwala rozwijać wersję v3 bez chaosu.
+
+---
+
+## 22. Podsumowanie
+
+PromptGlue v2 nie powinien być „większy dla zasady”. Powinien być przede wszystkim **bardziej przewidywalny, bardziej spójny i bardziej użyteczny**. Najważniejsza zmiana to przejście z myślenia o promptcie jako o ręcznie utrzymywanym tekście na myślenie o nim jako o **wyniku renderowania aktualnej sesji**. To rozwiązuje obecny błąd z usuwaniem bloków, porządkuje architekturę i tworzy fundament pod dalszy rozwój produktu.
+

--- a/prompt_assistant/cli.py
+++ b/prompt_assistant/cli.py
@@ -1,0 +1,67 @@
+"""Minimalny CLI hook dla PromptGlue."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from prompt_assistant.core import EntrySourceType, OutputFormat, Session, add_entry, build_output, create_entry
+
+
+def render_from_sources(
+    prompt_text: str,
+    sources: list[tuple[str, str]],
+    output_format: OutputFormat = OutputFormat.XML,
+) -> str:
+    """Renderuje finalny output na podstawie podanych źródeł tekstu."""
+    session = Session(prompt_text=prompt_text, output_format=output_format)
+    for path, content in sources:
+        entry = create_entry(path=path, source_type=EntrySourceType.FILE, content=content)
+        add_entry(session, entry)
+    return build_output(session).rendered_output
+
+
+def _parse_output_format(value: str) -> OutputFormat:
+    normalized = value.strip().lower()
+    if normalized == "markdown":
+        return OutputFormat.MARKDOWN
+    if normalized == "plain":
+        return OutputFormat.PLAIN
+    return OutputFormat.XML
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PromptGlue CLI (minimal hook)")
+    parser.add_argument("files", nargs="*", help="Ścieżki plików do dołączenia")
+    parser.add_argument("--prompt", default="", help="Treść promptu")
+    parser.add_argument(
+        "--format",
+        default="xml",
+        choices=["xml", "markdown", "plain"],
+        help="Profil outputu",
+    )
+    parser.add_argument("--output", default="", help="Plik wyjściowy (opcjonalnie)")
+
+    args = parser.parse_args()
+
+    sources: list[tuple[str, str]] = []
+    for path_str in args.files:
+        path = Path(path_str)
+        if not path.is_file():
+            raise SystemExit(f"Nie znaleziono pliku: {path}")
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise SystemExit(f"Błąd odczytu {path}: {exc}") from exc
+        sources.append((str(path), content))
+
+    rendered = render_from_sources(args.prompt, sources, _parse_output_format(args.format))
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+        return
+
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/prompt_assistant/core/__init__.py
+++ b/prompt_assistant/core/__init__.py
@@ -1,0 +1,22 @@
+"""Publiczny interfejs warstwy core."""
+from .models import BuildResult, Entry, EntrySourceType, OutputFormat, Session
+from .renderer import build_output
+from .session_ops import add_entry, clear_session, create_entry, get_entry, remove_entry, set_entry_inclusion
+from .token_service import count_entry_tokens, count_session_tokens
+
+__all__ = [
+    "BuildResult",
+    "Entry",
+    "EntrySourceType",
+    "OutputFormat",
+    "Session",
+    "add_entry",
+    "build_output",
+    "clear_session",
+    "count_entry_tokens",
+    "count_session_tokens",
+    "create_entry",
+    "get_entry",
+    "remove_entry",
+    "set_entry_inclusion",
+]

--- a/prompt_assistant/core/__init__.py
+++ b/prompt_assistant/core/__init__.py
@@ -1,5 +1,7 @@
 """Publiczny interfejs warstwy core."""
 from .models import BuildResult, Entry, EntrySourceType, OutputFormat, Session
+from .bulk_ops import exclude_entries, include_entries, remove_entries
+from .list_tools import FileListRecord, build_import_report, matches_filters
 from .renderer import build_output
 from .session_ops import add_entry, clear_session, create_entry, get_entry, remove_entry, set_entry_inclusion
 from .token_service import count_entry_tokens, count_session_tokens
@@ -8,15 +10,21 @@ __all__ = [
     "BuildResult",
     "Entry",
     "EntrySourceType",
+    "FileListRecord",
     "OutputFormat",
     "Session",
     "add_entry",
+    "build_import_report",
     "build_output",
     "clear_session",
     "count_entry_tokens",
     "count_session_tokens",
     "create_entry",
+    "exclude_entries",
     "get_entry",
+    "include_entries",
+    "matches_filters",
     "remove_entry",
+    "remove_entries",
     "set_entry_inclusion",
 ]

--- a/prompt_assistant/core/bulk_ops.py
+++ b/prompt_assistant/core/bulk_ops.py
@@ -1,0 +1,32 @@
+"""Masowe operacje na wpisach sesji."""
+from __future__ import annotations
+
+from .models import Session
+from .session_ops import remove_entry, set_entry_inclusion
+
+
+def include_entries(session: Session, entry_ids: list[str]) -> int:
+    """Włącza wskazane wpisy do outputu; zwraca liczbę zmian."""
+    changed = 0
+    for entry_id in entry_ids:
+        if set_entry_inclusion(session, entry_id, True):
+            changed += 1
+    return changed
+
+
+def exclude_entries(session: Session, entry_ids: list[str]) -> int:
+    """Wyłącza wskazane wpisy z outputu; zwraca liczbę zmian."""
+    changed = 0
+    for entry_id in entry_ids:
+        if set_entry_inclusion(session, entry_id, False):
+            changed += 1
+    return changed
+
+
+def remove_entries(session: Session, entry_ids: list[str]) -> int:
+    """Usuwa wskazane wpisy; zwraca liczbę usunięć."""
+    removed = 0
+    for entry_id in entry_ids:
+        if remove_entry(session, entry_id):
+            removed += 1
+    return removed

--- a/prompt_assistant/core/list_tools.py
+++ b/prompt_assistant/core/list_tools.py
@@ -1,0 +1,67 @@
+"""Narzędzia filtrowania listy i raportowania importu."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class FileListRecord:
+    """Dane używane do filtrowania pozycji listy plików."""
+
+    display_name: str
+    extension: str
+    status: str
+
+
+def matches_filters(
+    record: FileListRecord,
+    *,
+    name_query: str,
+    extension_query: str,
+    status_filter: str,
+) -> bool:
+    """Sprawdza, czy rekord spełnia filtry nazwy/rozszerzenia/statusu."""
+    normalized_name = name_query.strip().lower()
+    normalized_ext = extension_query.strip().lower()
+    normalized_status = status_filter.strip().lower()
+
+    if normalized_name and normalized_name not in record.display_name.lower():
+        return False
+
+    if normalized_ext:
+        candidate = normalized_ext if normalized_ext.startswith(".") else f".{normalized_ext}"
+        if record.extension.lower() != candidate:
+            return False
+
+    if normalized_status and normalized_status != "all":
+        if record.status.lower() != normalized_status:
+            return False
+
+    return True
+
+
+def build_import_report(
+    *,
+    added_count: int,
+    skipped_git: int,
+    skipped_custom: int,
+    skipped_binary: int,
+    read_errors: list[str],
+) -> str:
+    """Buduje czytelny raport po imporcie katalogu."""
+    lines = [
+        f"Dodano: {added_count}",
+        f"Pominięto .gitignore: {skipped_git}",
+        f"Pominięto custom: {skipped_custom}",
+        f"Pominięto binarne: {skipped_binary}",
+        f"Błędy odczytu: {len(read_errors)}",
+    ]
+
+    if read_errors:
+        lines.append("")
+        lines.append("Szczegóły błędów odczytu:")
+        lines.extend(read_errors[:10])
+        if len(read_errors) > 10:
+            lines.append(f"... (+{len(read_errors) - 10} kolejnych)")
+
+    return "\n".join(lines)

--- a/prompt_assistant/core/models.py
+++ b/prompt_assistant/core/models.py
@@ -1,0 +1,59 @@
+"""Modele domenowe dla sesji budowania promptu."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+
+
+class EntrySourceType(StrEnum):
+    """Typ źródła wpisu w sesji."""
+
+    FILE = "file"
+    DIRECTORY_FILE = "directory_file"
+    DIRECTORY_TREE = "directory_tree"
+
+
+class OutputFormat(StrEnum):
+    """Wspierane profile wyjścia renderera."""
+
+    XML = "xml"
+    MARKDOWN = "markdown"
+    PLAIN = "plain"
+
+
+@dataclass(slots=True)
+class Entry:
+    """Pojedynczy element wejścia sesji."""
+
+    entry_id: str
+    path: str
+    source_type: EntrySourceType
+    content: str
+    include_in_output: bool = True
+    read_error: str | None = None
+    is_binary: bool = False
+    size: int = 0
+    token_count_cache: int | None = None
+    last_loaded_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(slots=True)
+class Session:
+    """Stan sesji jako źródło prawdy dla renderowania outputu."""
+
+    prompt_text: str = ""
+    entries: list[Entry] = field(default_factory=list)
+    output_format: OutputFormat = OutputFormat.XML
+
+
+@dataclass(slots=True)
+class BuildResult:
+    """Wynik renderowania outputu ze stanu sesji."""
+
+    rendered_output: str
+    total_tokens: int
+    included_entries: int
+    excluded_entries: int
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)

--- a/prompt_assistant/core/renderer.py
+++ b/prompt_assistant/core/renderer.py
@@ -1,0 +1,68 @@
+"""Renderer finalnego outputu promptu ze stanu sesji."""
+from __future__ import annotations
+
+from .models import BuildResult, Entry, EntrySourceType, OutputFormat, Session
+from .token_service import count_session_tokens
+
+
+def _render_xml_entry(entry: Entry, lines: list[str]) -> None:
+    if entry.source_type == EntrySourceType.DIRECTORY_TREE:
+        lines.append("<directories>")
+        lines.extend(entry.content.splitlines())
+        lines.append("</directories>")
+        return
+
+    lines.append(f"<file path='{entry.path}'>")
+    lines.extend(entry.content.splitlines())
+    lines.append("</file>")
+
+
+def _render_plain_entry(entry: Entry, lines: list[str]) -> None:
+    lines.append(f"FILE: {entry.path}")
+    lines.extend(entry.content.splitlines())
+
+
+def _render_markdown_entry(entry: Entry, lines: list[str]) -> None:
+    lines.append(f"### {entry.path}")
+    lines.append("```")
+    lines.extend(entry.content.splitlines())
+    lines.append("```")
+
+
+def build_output(session: Session) -> BuildResult:
+    """Buduje finalny output ze stanu sesji."""
+    lines: list[str] = []
+    if session.prompt_text:
+        lines.append(session.prompt_text)
+
+    included = 0
+    excluded = 0
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    for entry in session.entries:
+        if entry.read_error:
+            errors.append(f"{entry.path}: {entry.read_error}")
+            excluded += 1
+            continue
+        if not entry.include_in_output:
+            excluded += 1
+            continue
+
+        included += 1
+        if session.output_format == OutputFormat.MARKDOWN:
+            _render_markdown_entry(entry, lines)
+        elif session.output_format == OutputFormat.PLAIN:
+            _render_plain_entry(entry, lines)
+        else:
+            _render_xml_entry(entry, lines)
+
+    _prompt_tokens, _attachment_tokens, total = count_session_tokens(session)
+    return BuildResult(
+        rendered_output="\n".join(lines),
+        total_tokens=total,
+        included_entries=included,
+        excluded_entries=excluded,
+        warnings=warnings,
+        errors=errors,
+    )

--- a/prompt_assistant/core/session_ops.py
+++ b/prompt_assistant/core/session_ops.py
@@ -1,0 +1,66 @@
+"""Operacje na stanie sesji."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+from .models import Entry, EntrySourceType, Session
+
+
+def create_entry(
+    path: str,
+    source_type: EntrySourceType,
+    content: str,
+    *,
+    include_in_output: bool = True,
+    read_error: str | None = None,
+    is_binary: bool = False,
+    size: int = 0,
+) -> Entry:
+    """Tworzy wpis sesji z unikalnym identyfikatorem."""
+    return Entry(
+        entry_id=str(uuid4()),
+        path=path,
+        source_type=source_type,
+        content=content,
+        include_in_output=include_in_output,
+        read_error=read_error,
+        is_binary=is_binary,
+        size=size,
+    )
+
+
+def add_entry(session: Session, entry: Entry) -> None:
+    """Dodaje wpis do sesji."""
+    session.entries.append(entry)
+
+
+def remove_entry(session: Session, entry_id: str) -> bool:
+    """Usuwa wpis po identyfikatorze; zwraca True gdy usunięto."""
+    for index, entry in enumerate(session.entries):
+        if entry.entry_id == entry_id:
+            del session.entries[index]
+            return True
+    return False
+
+
+def set_entry_inclusion(session: Session, entry_id: str, include: bool) -> bool:
+    """Ustawia flagę include_in_output wpisu."""
+    entry = get_entry(session, entry_id)
+    if entry is None:
+        return False
+    entry.include_in_output = include
+    return True
+
+
+def get_entry(session: Session, entry_id: str) -> Entry | None:
+    """Zwraca wpis po ID albo None."""
+    for entry in session.entries:
+        if entry.entry_id == entry_id:
+            return entry
+    return None
+
+
+def clear_session(session: Session) -> None:
+    """Czyści prompt i wszystkie wpisy sesji."""
+    session.prompt_text = ""
+    session.entries.clear()

--- a/prompt_assistant/core/token_service.py
+++ b/prompt_assistant/core/token_service.py
@@ -1,0 +1,25 @@
+"""Liczenie tokenów dla sesji i wpisów."""
+from __future__ import annotations
+
+from prompt_assistant.utils import count_tokens
+
+from .models import Entry, Session
+
+
+def count_entry_tokens(entry: Entry) -> int:
+    """Zwraca liczbę tokenów wpisu z prostym cache."""
+    if entry.token_count_cache is None:
+        entry.token_count_cache = count_tokens(entry.content)
+    return entry.token_count_cache
+
+
+def count_session_tokens(session: Session) -> tuple[int, int, int]:
+    """Zwraca tokeny: (prompt, attachments, suma)."""
+    prompt_tokens = count_tokens(session.prompt_text) if session.prompt_text else 0
+
+    attachment_tokens = 0
+    for entry in session.entries:
+        if entry.include_in_output and entry.read_error is None:
+            attachment_tokens += count_entry_tokens(entry)
+
+    return prompt_tokens, attachment_tokens, prompt_tokens + attachment_tokens

--- a/prompt_assistant/exporter.py
+++ b/prompt_assistant/exporter.py
@@ -1,0 +1,8 @@
+"""Funkcje eksportu finalnego outputu."""
+from __future__ import annotations
+
+
+def export_text_to_file(path: str, content: str) -> None:
+    """Zapisuje wynik do pliku UTF-8."""
+    with open(path, "w", encoding="utf-8") as file_handle:
+        file_handle.write(content)

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 import pathspec
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtGui import QFont, QGuiApplication
 from PyQt5.QtWidgets import (
     QFileDialog,
     QListWidgetItem,
@@ -22,14 +22,19 @@ from PyQt5.QtWidgets import (
 from prompt_assistant.config import MAX_DIR_SIZE, WARNING_TOKEN_LIMIT, CRITICAL_TOKEN_LIMIT
 from prompt_assistant.core import (
     EntrySourceType,
+    FileListRecord,
     OutputFormat,
     add_entry,
+    build_import_report,
     build_output,
     clear_session,
     count_entry_tokens,
     count_session_tokens,
     create_entry,
+    exclude_entries,
     get_entry,
+    include_entries,
+    matches_filters,
     remove_entry,
     set_entry_inclusion,
 )
@@ -43,6 +48,31 @@ def _sync_prompt_text(window: PromptAssistantWindow) -> None:
     window.session.prompt_text = window.text_edit.toPlainText()
 
 
+def _get_file_status(file_obj: dict) -> str:
+    if file_obj.get("read_error"):
+        return "error"
+    if file_obj.get("excluded"):
+        return "excluded"
+    return "active"
+
+
+def _refresh_item_visual(item: QListWidgetItem, file_obj: dict) -> None:
+    status = _get_file_status(file_obj)
+    display_name = file_obj.get("display_name") or file_obj.get("name") or file_obj.get("rel") or "plik"
+
+    if status == "error":
+        error_text = file_obj.get("read_error", "nieznany błąd")
+        item.setText(f"{display_name} [error: {error_text}]")
+    elif status == "excluded":
+        item.setText(f"{display_name} [excluded]")
+    else:
+        item.setText(display_name)
+
+    font: QFont = item.font()
+    font.setStrikeOut(status in ("excluded", "error"))
+    item.setFont(font)
+
+
 def _sync_directory_tree_entries(window: PromptAssistantWindow) -> None:
     """Synchronizuje include tree-entry katalogu na podstawie stanu jego plików."""
     dirs_to_remove: List[dict] = []
@@ -52,11 +82,17 @@ def _sync_directory_tree_entries(window: PromptAssistantWindow) -> None:
             dirs_to_remove.append(directory)
             continue
 
-        has_active_files = any(not f["excluded"] for f in directory["files"])
+        has_active_files = any(_get_file_status(f) == "active" for f in directory["files"])
         set_entry_inclusion(window.session, directory["tree_entry_id"], has_active_files)
 
     for directory in dirs_to_remove:
         window.attached_dirs.remove(directory)
+
+
+def _build_current_output(window: PromptAssistantWindow):
+    _sync_prompt_text(window)
+    _sync_directory_tree_entries(window)
+    return build_output(window.session)
 
 
 # --------------------------------------------------------------------------- UI
@@ -90,51 +126,113 @@ def _toggle_gitignore(window: PromptAssistantWindow, state: int) -> None:
 
 def _create_file_item(
     window: PromptAssistantWindow,
-    display_name: str,
     file_obj: dict,
     is_dir_file: bool = False,
 ) -> None:
     """Dodaje wpis do QListWidget i przypina obiekt pliku w UserRole."""
-    item = QListWidgetItem(display_name)
+    item = QListWidgetItem(file_obj["display_name"])
     item.setData(Qt.UserRole, ("dir_file" if is_dir_file else "file", file_obj))
+    _refresh_item_visual(item, file_obj)
     window.files_list.addItem(item)
 
 
-def _create_file_entry(path: str, content: str, source_type: EntrySourceType):
+def _create_file_entry(path: str, content: str, source_type: EntrySourceType, *, read_error: str | None = None):
     size = len(content.encode("utf-8"))
-    return create_entry(path=path, source_type=source_type, content=content, size=size)
+    return create_entry(
+        path=path,
+        source_type=source_type,
+        content=content,
+        size=size,
+        include_in_output=(read_error is None),
+        read_error=read_error,
+    )
 
 
-def _build_current_output(window: PromptAssistantWindow):
-    _sync_prompt_text(window)
-    _sync_directory_tree_entries(window)
-    return build_output(window.session)
+def _iter_file_items(window: PromptAssistantWindow):
+    for idx in range(window.files_list.count()):
+        item = window.files_list.item(idx)
+        role = item.data(Qt.UserRole)
+        if not role:
+            continue
+        kind, file_obj = role
+        if kind in ("file", "dir_file"):
+            yield item, file_obj
+
+
+# --------------------------------------------------------------------- filters
+
+def apply_list_filters(window: PromptAssistantWindow) -> None:
+    """Filtruje listę plików po nazwie, rozszerzeniu i statusie."""
+    name_query = window.name_filter_edit.text()
+    extension_query = window.ext_filter_edit.text()
+    status_filter = window.status_filter_combo.currentData() or "all"
+
+    for item, file_obj in _iter_file_items(window):
+        extension = file_obj.get("extension", "")
+        record = FileListRecord(
+            display_name=file_obj.get("display_name", ""),
+            extension=extension,
+            status=_get_file_status(file_obj),
+        )
+        visible = matches_filters(
+            record,
+            name_query=name_query,
+            extension_query=extension_query,
+            status_filter=status_filter,
+        )
+        item.setHidden(not visible)
 
 
 # --------------------------------------------------------------------- actions
 
 def attach_files(window: PromptAssistantWindow) -> None:
     paths, _ = QFileDialog.getOpenFileNames(window, "Wybierz pliki...", "", "*.*")
+    read_errors: List[str] = []
+
     for path in paths:
         if not os.path.isfile(path):
             continue
+
+        name = os.path.basename(path)
+        extension = os.path.splitext(name)[1].lower()
+
         try:
             with open(path, encoding="utf-8") as file_handle:
                 content = file_handle.read()
-            name = os.path.basename(path)
             entry = _create_file_entry(name, content, EntrySourceType.FILE)
             add_entry(window.session, entry)
             file_obj = {
                 "name": name,
+                "display_name": name,
                 "content": content,
                 "excluded": False,
                 "entry_id": entry.entry_id,
+                "extension": extension,
+                "read_error": None,
             }
-            window.attached_files.append(file_obj)
-            _create_file_item(window, name, file_obj)
-        except Exception:
-            pass
+        except Exception as exc:
+            error_text = str(exc)
+            entry = _create_file_entry(name, "", EntrySourceType.FILE, read_error=error_text)
+            add_entry(window.session, entry)
+            file_obj = {
+                "name": name,
+                "display_name": name,
+                "content": "",
+                "excluded": True,
+                "entry_id": entry.entry_id,
+                "extension": extension,
+                "read_error": error_text,
+            }
+            read_errors.append(f"{name}: {error_text}")
+
+        window.attached_files.append(file_obj)
+        _create_file_item(window, file_obj)
+
+    if read_errors:
+        QMessageBox.warning(window, "Błędy odczytu plików", "\n".join(read_errors))
+
     _update_token_label(window)
+    apply_list_filters(window)
 
 
 def attach_directory(window: PromptAssistantWindow) -> None:
@@ -161,6 +259,7 @@ def attach_directory(window: PromptAssistantWindow) -> None:
 
     collected: List[Dict] = []
     skipped = {"binary": 0, "git": 0, "custom": 0}
+    read_errors: List[str] = []
     base = len(dir_path) + 1
 
     for root, dirs, files in os.walk(dir_path):
@@ -169,6 +268,7 @@ def attach_directory(window: PromptAssistantWindow) -> None:
         for filename in files:
             full = os.path.join(root, filename)
             rel = full[base:].replace(os.sep, "/")
+
             if git_spec and git_spec.match_file(rel):
                 skipped["git"] += 1
                 continue
@@ -178,15 +278,32 @@ def attach_directory(window: PromptAssistantWindow) -> None:
             if is_binary(full):
                 skipped["binary"] += 1
                 continue
+
             try:
                 with open(full, encoding="utf-8") as file_handle:
                     content = file_handle.read()
-                    collected.append({"rel": rel, "content": content, "excluded": False})
-            except Exception:
-                skipped["binary"] += 1
+                collected.append(
+                    {
+                        "rel": rel,
+                        "display_name": f"{os.path.basename(dir_path)}/{rel}",
+                        "content": content,
+                        "excluded": False,
+                        "extension": os.path.splitext(rel)[1].lower(),
+                        "read_error": None,
+                    }
+                )
+            except Exception as exc:
+                read_errors.append(f"{rel}: {exc}")
 
     if not collected:
-        QMessageBox.information(window, "Brak plików", "Nie znaleziono plików tekstowych.")
+        report = build_import_report(
+            added_count=0,
+            skipped_git=skipped["git"],
+            skipped_custom=skipped["custom"],
+            skipped_binary=skipped["binary"],
+            read_errors=read_errors,
+        )
+        QMessageBox.information(window, "Brak plików", report)
         return
 
     tree = render_tree_structure([file_item["rel"] for file_item in collected])
@@ -210,13 +327,19 @@ def attach_directory(window: PromptAssistantWindow) -> None:
     )
 
     for file_item in collected:
-        _create_file_item(window, f"{name}/{file_item['rel']}", file_item, is_dir_file=True)
+        _create_file_item(window, file_item, is_dir_file=True)
 
-    msgs = [f"{value} {key}" for key, value in skipped.items() if value]
-    if msgs:
-        QMessageBox.information(window, "Pominięto", ", ".join(msgs))
+    report = build_import_report(
+        added_count=len(collected),
+        skipped_git=skipped["git"],
+        skipped_custom=skipped["custom"],
+        skipped_binary=skipped["binary"],
+        read_errors=read_errors,
+    )
+    QMessageBox.information(window, "Raport importu katalogu", report)
 
     _update_token_label(window)
+    apply_list_filters(window)
 
 
 def copy_text(window: PromptAssistantWindow) -> None:
@@ -306,6 +429,61 @@ def preview_final_output(window: PromptAssistantWindow) -> None:
     dialog.exec_()
 
 
+def _selected_file_items(window: PromptAssistantWindow) -> list[tuple[QListWidgetItem, dict]]:
+    selected: list[tuple[QListWidgetItem, dict]] = []
+    for item in window.files_list.selectedItems():
+        role = item.data(Qt.UserRole)
+        if not role:
+            continue
+        kind, file_obj = role
+        if kind in ("file", "dir_file"):
+            selected.append((item, file_obj))
+    return selected
+
+
+def bulk_include_selected(window: PromptAssistantWindow) -> None:
+    selected = _selected_file_items(window)
+    entry_ids = [file_obj["entry_id"] for _item, file_obj in selected if not file_obj.get("read_error")]
+    include_entries(window.session, entry_ids)
+
+    for item, file_obj in selected:
+        if file_obj.get("read_error"):
+            continue
+        file_obj["excluded"] = False
+        _refresh_item_visual(item, file_obj)
+
+    _sync_directory_tree_entries(window)
+    _update_token_label(window)
+    apply_list_filters(window)
+
+
+def bulk_exclude_selected(window: PromptAssistantWindow) -> None:
+    selected = _selected_file_items(window)
+    entry_ids = [file_obj["entry_id"] for _item, file_obj in selected if not file_obj.get("read_error")]
+    exclude_entries(window.session, entry_ids)
+
+    for item, file_obj in selected:
+        if file_obj.get("read_error"):
+            continue
+        file_obj["excluded"] = True
+        _refresh_item_visual(item, file_obj)
+
+    _sync_directory_tree_entries(window)
+    _update_token_label(window)
+    apply_list_filters(window)
+
+
+def bulk_remove_selected(window: PromptAssistantWindow) -> None:
+    selected = _selected_file_items(window)
+    for item, file_obj in selected:
+        row = window.files_list.row(item)
+        window.files_list.takeItem(row)
+        remove_file_from_session(window, file_obj)
+
+    _update_token_label(window)
+    apply_list_filters(window)
+
+
 def clear_all(window: PromptAssistantWindow) -> None:
     window.text_edit.clear()
     window.files_list.clear()
@@ -343,7 +521,6 @@ def remove_file_from_session(window: PromptAssistantWindow, file_obj: dict) -> N
                 break
 
     _sync_directory_tree_entries(window)
-    _update_token_label(window)
 
 
 def show_token_distribution(window: PromptAssistantWindow) -> None:
@@ -354,7 +531,7 @@ def show_token_distribution(window: PromptAssistantWindow) -> None:
 
     file_counts: List[tuple[str, int]] = []
     for file_obj in window.attached_files:
-        if file_obj["excluded"]:
+        if _get_file_status(file_obj) != "active":
             continue
         entry = get_entry(window.session, file_obj["entry_id"])
         if entry is None:
@@ -369,7 +546,7 @@ def show_token_distribution(window: PromptAssistantWindow) -> None:
 
         files: List[tuple[str, int]] = []
         for file_obj in directory["files"]:
-            if file_obj["excluded"]:
+            if _get_file_status(file_obj) != "active":
                 continue
             entry = get_entry(window.session, file_obj["entry_id"])
             if entry is None:

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -2,55 +2,72 @@
 from __future__ import annotations
 
 import os
-from typing import List, Dict
+from typing import Dict, List
 
 import pathspec
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication, QFont
+from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtWidgets import (
     QFileDialog,
     QListWidgetItem,
     QMessageBox,
     QDialog,
     QVBoxLayout,
-    QLabel,
     QPlainTextEdit,
     QPushButton,
     QHBoxLayout,
 )
 
 from prompt_assistant.config import MAX_DIR_SIZE, WARNING_TOKEN_LIMIT, CRITICAL_TOKEN_LIMIT
-from prompt_assistant.utils import (
-    count_tokens,
-    render_tree_structure,
-    is_binary,
-    build_gitignore_spec,
+from prompt_assistant.core import (
+    EntrySourceType,
+    add_entry,
+    build_output,
+    clear_session,
+    count_entry_tokens,
+    count_session_tokens,
+    create_entry,
+    get_entry,
+    remove_entry,
+    set_entry_inclusion,
 )
+from prompt_assistant.utils import render_tree_structure, is_binary, build_gitignore_spec
 from .ui import PromptAssistantWindow
 from .preview_dialog import FilePreviewDialog
 
 
+def _sync_prompt_text(window: PromptAssistantWindow) -> None:
+    window.session.prompt_text = window.text_edit.toPlainText()
+
+
+def _sync_directory_tree_entries(window: PromptAssistantWindow) -> None:
+    """Synchronizuje include tree-entry katalogu na podstawie stanu jego plików."""
+    dirs_to_remove: List[dict] = []
+    for directory in window.attached_dirs:
+        if not directory["files"]:
+            remove_entry(window.session, directory["tree_entry_id"])
+            dirs_to_remove.append(directory)
+            continue
+
+        has_active_files = any(not f["excluded"] for f in directory["files"])
+        set_entry_inclusion(window.session, directory["tree_entry_id"], has_active_files)
+
+    for directory in dirs_to_remove:
+        window.attached_dirs.remove(directory)
+
+
 # --------------------------------------------------------------------------- UI
+
 def _update_token_label(window: PromptAssistantWindow) -> None:
     """Przelicza tokeny promptu i załączników z pominięciem wykluczonych plików."""
-    prompt_text = window.text_edit.toPlainText()
-    window.prompt_tokens = count_tokens(prompt_text) if prompt_text else 0
+    _sync_prompt_text(window)
+    _sync_directory_tree_entries(window)
 
-    attach_tokens = 0
-    # --- pliki pojedyncze
-    for f in window.attached_files:
-        if not f["excluded"]:
-            attach_tokens += count_tokens(f["content"])
-    # --- pliki z katalogów
-    for d in window.attached_dirs:
-        attach_tokens += count_tokens(d["tree"])
-        for f in d["files"]:
-            if not f["excluded"]:
-                attach_tokens += count_tokens(f["content"])
-
+    prompt_tokens, attach_tokens, total = count_session_tokens(window.session)
+    window.prompt_tokens = prompt_tokens
     window.attachments_tokens = attach_tokens
-    total = window.prompt_tokens + attach_tokens
     window.total_tokens = total
+
     window.token_label.setText(
         f"Tokeny: prompt: {window.prompt_tokens} | pliki: {attach_tokens} | suma: {total}"
     )
@@ -66,7 +83,8 @@ def _toggle_gitignore(window: PromptAssistantWindow, state: int) -> None:
     window.ignore_gitignored = state == Qt.Checked
 
 
-# -------------------------------------------------------------------- helpers –
+# -------------------------------------------------------------------- helpers --
+
 def _create_file_item(
     window: PromptAssistantWindow,
     display_name: str,
@@ -76,21 +94,33 @@ def _create_file_item(
     """Dodaje wpis do QListWidget i przypina obiekt pliku w UserRole."""
     item = QListWidgetItem(display_name)
     item.setData(Qt.UserRole, ("dir_file" if is_dir_file else "file", file_obj))
-    lw = window.files_list
-    lw.addItem(item)
+    window.files_list.addItem(item)
+
+
+def _create_file_entry(path: str, content: str, source_type: EntrySourceType):
+    size = len(content.encode("utf-8"))
+    return create_entry(path=path, source_type=source_type, content=content, size=size)
 
 
 # --------------------------------------------------------------------- actions
+
 def attach_files(window: PromptAssistantWindow) -> None:
     paths, _ = QFileDialog.getOpenFileNames(window, "Wybierz pliki...", "", "*.*")
     for path in paths:
         if not os.path.isfile(path):
             continue
         try:
-            with open(path, encoding="utf-8") as f:
-                content = f.read()
+            with open(path, encoding="utf-8") as file_handle:
+                content = file_handle.read()
             name = os.path.basename(path)
-            file_obj = {"name": name, "content": content, "excluded": False}
+            entry = _create_file_entry(name, content, EntrySourceType.FILE)
+            add_entry(window.session, entry)
+            file_obj = {
+                "name": name,
+                "content": content,
+                "excluded": False,
+                "entry_id": entry.entry_id,
+            }
             window.attached_files.append(file_obj)
             _create_file_item(window, name, file_obj)
         except Exception:
@@ -103,14 +133,13 @@ def attach_directory(window: PromptAssistantWindow) -> None:
     if not dir_path:
         return
 
-    # --- Size sanity-check
     total_size = 0
     for root, dirs, files in os.walk(dir_path):
         if ".git" in dirs:
             dirs.remove(".git")
-        for f in files:
+        for filename in files:
             try:
-                total_size += os.path.getsize(os.path.join(root, f))
+                total_size += os.path.getsize(os.path.join(root, filename))
             except OSError:
                 pass
         if total_size > MAX_DIR_SIZE:
@@ -118,7 +147,7 @@ def attach_directory(window: PromptAssistantWindow) -> None:
             return
 
     git_spec = build_gitignore_spec(dir_path) if window.ignore_gitignored else None
-    custom = [p.strip() for p in window.exclude_edit.text().split(",") if p.strip()]
+    custom = [pattern.strip() for pattern in window.exclude_edit.text().split(",") if pattern.strip()]
     custom_spec = pathspec.PathSpec.from_lines("gitwildmatch", custom) if custom else None
 
     collected: List[Dict] = []
@@ -128,10 +157,9 @@ def attach_directory(window: PromptAssistantWindow) -> None:
     for root, dirs, files in os.walk(dir_path):
         if ".git" in dirs:
             dirs.remove(".git")
-        for f in files:
-            full = os.path.join(root, f)
+        for filename in files:
+            full = os.path.join(root, filename)
             rel = full[base:].replace(os.sep, "/")
-            # --- filters
             if git_spec and git_spec.match_file(rel):
                 skipped["git"] += 1
                 continue
@@ -141,10 +169,10 @@ def attach_directory(window: PromptAssistantWindow) -> None:
             if is_binary(full):
                 skipped["binary"] += 1
                 continue
-            # --- collect
             try:
-                with open(full, encoding="utf-8") as fh:
-                    collected.append({"rel": rel, "content": fh.read(), "excluded": False})
+                with open(full, encoding="utf-8") as file_handle:
+                    content = file_handle.read()
+                    collected.append({"rel": rel, "content": content, "excluded": False})
             except Exception:
                 skipped["binary"] += 1
 
@@ -152,16 +180,30 @@ def attach_directory(window: PromptAssistantWindow) -> None:
         QMessageBox.information(window, "Brak plików", "Nie znaleziono plików tekstowych.")
         return
 
-    tree = render_tree_structure([f["rel"] for f in collected])
+    tree = render_tree_structure([file_item["rel"] for file_item in collected])
     name = os.path.basename(dir_path)
-    window.attached_dirs.append({"name": name, "files": collected, "tree": tree})
 
-    # --- UI items
-    for f in collected:
-        _create_file_item(window, f"{name}/{f['rel']}", f, is_dir_file=True)
+    tree_entry = _create_file_entry(f"{name}/.tree", tree, EntrySourceType.DIRECTORY_TREE)
+    add_entry(window.session, tree_entry)
 
-    # --- info o pominieciach
-    msgs = [f"{v} {k}" for k, v in skipped.items() if v]
+    for file_item in collected:
+        entry = _create_file_entry(file_item["rel"], file_item["content"], EntrySourceType.DIRECTORY_FILE)
+        add_entry(window.session, entry)
+        file_item["entry_id"] = entry.entry_id
+
+    window.attached_dirs.append(
+        {
+            "name": name,
+            "files": collected,
+            "tree": tree,
+            "tree_entry_id": tree_entry.entry_id,
+        }
+    )
+
+    for file_item in collected:
+        _create_file_item(window, f"{name}/{file_item['rel']}", file_item, is_dir_file=True)
+
+    msgs = [f"{value} {key}" for key, value in skipped.items() if value]
     if msgs:
         QMessageBox.information(window, "Pominięto", ", ".join(msgs))
 
@@ -169,40 +211,10 @@ def attach_directory(window: PromptAssistantWindow) -> None:
 
 
 def copy_text(window: PromptAssistantWindow) -> None:
-    """Buduje prompt + wszystkie załączniki (bez excluded) i kopiuje do clipboard."""
-    parts: List[str] = []
-    p = window.text_edit.toPlainText()
-    if p:
-        parts.append(p)
-
-    # --- katalogi
-    for d in window.attached_dirs:
-        parts.append("<directories>")
-        parts.extend(d["tree"].splitlines())
-        parts.append("</directories>")
-        for f in d["files"]:
-            if f["excluded"]:
-                continue
-
-            rel_path = f["rel"]
-            if "/" in rel_path:
-                tag_path = f"/{rel_path}"
-            else:
-                tag_path = rel_path
-
-            parts.append(f"<file path='{tag_path}'>")
-            parts.extend(f["content"].splitlines())
-            parts.append(f"</file>")
-
-    # --- pliki pojedyncze
-    for f in window.attached_files:
-        if f["excluded"]:
-            continue
-        parts.append(f"<file path='{f['name']}'>")
-        parts.extend(f["content"].splitlines())
-        parts.append(f"</file>")
-
-    QGuiApplication.clipboard().setText("\n".join(parts))
+    """Buduje finalny output i kopiuje do clipboard."""
+    _sync_prompt_text(window)
+    result = build_output(window.session)
+    QGuiApplication.clipboard().setText(result.rendered_output)
 
 
 def clear_all(window: PromptAssistantWindow) -> None:
@@ -210,11 +222,13 @@ def clear_all(window: PromptAssistantWindow) -> None:
     window.files_list.clear()
     window.attached_dirs.clear()
     window.attached_files.clear()
+    clear_session(window.session)
     window.prompt_tokens = window.attachments_tokens = window.total_tokens = 0
     window.token_label.setText("Tokeny: prompt: 0 | pliki: 0 | suma: 0")
 
 
 # ----------------------------------------------------------------- preview slot
+
 def preview_file(window: PromptAssistantWindow, item: QListWidgetItem) -> None:
     """Obsługa podwójnego kliknięcia na element listy."""
     role = item.data(Qt.UserRole)
@@ -223,36 +237,58 @@ def preview_file(window: PromptAssistantWindow, item: QListWidgetItem) -> None:
     kind, file_obj = role
     if kind not in ("file", "dir_file"):
         return
-    dlg = FilePreviewDialog(window, item, file_obj, is_dir_file=(kind == "dir_file"))
-    dlg.exec_()
+    dialog = FilePreviewDialog(window, item, file_obj, is_dir_file=(kind == "dir_file"))
+    dialog.exec_()
+
+
+def remove_file_from_session(window: PromptAssistantWindow, file_obj: dict) -> None:
+    """Usuwa wskazany plik z modeli GUI i z sesji core."""
+    remove_entry(window.session, file_obj["entry_id"])
+
+    if file_obj in window.attached_files:
+        window.attached_files.remove(file_obj)
+    else:
+        for directory in window.attached_dirs:
+            if file_obj in directory["files"]:
+                directory["files"].remove(file_obj)
+                break
+
+    _sync_directory_tree_entries(window)
+    _update_token_label(window)
+
 
 def show_token_distribution(window: PromptAssistantWindow) -> None:
     """Wyświetla modalne okno z rozkładem tokenów promptu i załączonych plików."""
-    # Dynamiczne liczenie
-    prompt_text = window.text_edit.toPlainText() or ""
-    prompt_tokens = count_tokens(prompt_text)
+    _sync_prompt_text(window)
 
-    # Pliki pojedyncze
-    file_counts: List[tuple[str, int]] = [
-        (f['name'], count_tokens(f['content']))
-        for f in window.attached_files
-        if not f['excluded']
-    ]
-    file_counts.sort(key=lambda x: x[1], reverse=True)
+    prompt_tokens, _attach_tokens, _total = count_session_tokens(window.session)
 
-    # Katalogi
+    file_counts: List[tuple[str, int]] = []
+    for file_obj in window.attached_files:
+        if file_obj["excluded"]:
+            continue
+        entry = get_entry(window.session, file_obj["entry_id"])
+        if entry is None:
+            continue
+        file_counts.append((file_obj["name"], count_entry_tokens(entry)))
+    file_counts.sort(key=lambda item: item[1], reverse=True)
+
     dir_data: List[tuple[str, int, List[tuple[str, int]]]] = []
-    for d in window.attached_dirs:
-        tree_tokens = count_tokens(d['tree'])
-        files = [
-            (f['rel'], count_tokens(f['content']))
-            for f in d['files']
-            if not f['excluded']
-        ]
-        files.sort(key=lambda x: x[1], reverse=True)
-        dir_data.append((d['name'], tree_tokens, files))
+    for directory in window.attached_dirs:
+        tree_entry = get_entry(window.session, directory["tree_entry_id"])
+        tree_tokens = count_entry_tokens(tree_entry) if tree_entry else 0
 
-    # Budowanie raportu
+        files: List[tuple[str, int]] = []
+        for file_obj in directory["files"]:
+            if file_obj["excluded"]:
+                continue
+            entry = get_entry(window.session, file_obj["entry_id"])
+            if entry is None:
+                continue
+            files.append((file_obj["rel"], count_entry_tokens(entry)))
+        files.sort(key=lambda item: item[1], reverse=True)
+        dir_data.append((directory["name"], tree_tokens, files))
+
     lines: List[str] = []
     lines.append("Prompt")
     lines.append(f"  prompt: {prompt_tokens} tokenów")
@@ -272,18 +308,15 @@ def show_token_distribution(window: PromptAssistantWindow) -> None:
             lines.append("")
     report = "\n".join(lines)
 
-    # Tworzenie dialogu
     dialog = QDialog(window)
     dialog.setWindowTitle("Rozkład tokenów")
     dialog.setMinimumWidth(600)
     layout = QVBoxLayout(dialog)
 
-    # Raport w QPlainTextEdit
     text = QPlainTextEdit(report)
     text.setReadOnly(True)
     layout.addWidget(text)
 
-    # Przyciski
     btn_layout = QHBoxLayout()
     btn_layout.addStretch(1)
     btn_close = QPushButton("Zamknij")
@@ -293,7 +326,9 @@ def show_token_distribution(window: PromptAssistantWindow) -> None:
 
     dialog.exec_()
 
+
 # ----------------------------------------------------------------------- setup
+
 def setup_ui(window: PromptAssistantWindow) -> None:
     from .ui import build_ui
 

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -413,15 +413,15 @@ def preview_final_output(window: PromptAssistantWindow) -> None:
     btn_layout = QHBoxLayout()
     btn_layout.addStretch(1)
 
-    btn_copy = QPushButton("Kopiuj")
+    btn_copy = QPushButton("Copy")
     btn_copy.clicked.connect(lambda: QGuiApplication.clipboard().setText(text.toPlainText()))
     btn_layout.addWidget(btn_copy)
 
-    btn_export = QPushButton("Eksportuj")
+    btn_export = QPushButton("Export")
     btn_export.clicked.connect(lambda: export_text(window, text.toPlainText()))
     btn_layout.addWidget(btn_export)
 
-    btn_close = QPushButton("Zamknij")
+    btn_close = QPushButton("Close")
     btn_close.clicked.connect(dialog.accept)
     btn_layout.addWidget(btn_close)
 
@@ -585,7 +585,7 @@ def show_token_distribution(window: PromptAssistantWindow) -> None:
 
     btn_layout = QHBoxLayout()
     btn_layout.addStretch(1)
-    btn_close = QPushButton("Zamknij")
+    btn_close = QPushButton("Close")
     btn_close.clicked.connect(dialog.accept)
     btn_layout.addWidget(btn_close)
     layout.addLayout(btn_layout)

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -14,6 +14,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QVBoxLayout,
     QPlainTextEdit,
+    QLabel,
     QPushButton,
     QHBoxLayout,
 )
@@ -21,6 +22,7 @@ from PyQt5.QtWidgets import (
 from prompt_assistant.config import MAX_DIR_SIZE, WARNING_TOKEN_LIMIT, CRITICAL_TOKEN_LIMIT
 from prompt_assistant.core import (
     EntrySourceType,
+    OutputFormat,
     add_entry,
     build_output,
     clear_session,
@@ -31,6 +33,7 @@ from prompt_assistant.core import (
     remove_entry,
     set_entry_inclusion,
 )
+from prompt_assistant.exporter import export_text_to_file
 from prompt_assistant.utils import render_tree_structure, is_binary, build_gitignore_spec
 from .ui import PromptAssistantWindow
 from .preview_dialog import FilePreviewDialog
@@ -100,6 +103,12 @@ def _create_file_item(
 def _create_file_entry(path: str, content: str, source_type: EntrySourceType):
     size = len(content.encode("utf-8"))
     return create_entry(path=path, source_type=source_type, content=content, size=size)
+
+
+def _build_current_output(window: PromptAssistantWindow):
+    _sync_prompt_text(window)
+    _sync_directory_tree_entries(window)
+    return build_output(window.session)
 
 
 # --------------------------------------------------------------------- actions
@@ -212,9 +221,89 @@ def attach_directory(window: PromptAssistantWindow) -> None:
 
 def copy_text(window: PromptAssistantWindow) -> None:
     """Buduje finalny output i kopiuje do clipboard."""
-    _sync_prompt_text(window)
-    result = build_output(window.session)
+    result = _build_current_output(window)
     QGuiApplication.clipboard().setText(result.rendered_output)
+
+
+def set_output_format(window: PromptAssistantWindow, _index: int) -> None:
+    """Ustawia format renderowania outputu według wyboru użytkownika."""
+    format_value = window.output_format_combo.currentData()
+    if format_value == OutputFormat.MARKDOWN.value:
+        window.session.output_format = OutputFormat.MARKDOWN
+    elif format_value == OutputFormat.PLAIN.value:
+        window.session.output_format = OutputFormat.PLAIN
+    else:
+        window.session.output_format = OutputFormat.XML
+
+
+def export_text(window: PromptAssistantWindow, output_text: str | None = None) -> bool:
+    """Eksportuje wynik do pliku `.md` lub `.txt`."""
+    text_to_export = output_text if output_text is not None else _build_current_output(window).rendered_output
+    if not text_to_export:
+        QMessageBox.information(window, "Brak danych", "Brak treści do eksportu.")
+        return False
+
+    default_ext = ".txt" if window.session.output_format == OutputFormat.PLAIN else ".md"
+    path, _ = QFileDialog.getSaveFileName(
+        window,
+        "Eksportuj wynik",
+        f"prompt_output{default_ext}",
+        "Markdown (*.md);;Text (*.txt)",
+    )
+    if not path:
+        return False
+
+    if not path.endswith(".md") and not path.endswith(".txt"):
+        path = f"{path}{default_ext}"
+
+    try:
+        export_text_to_file(path, text_to_export)
+    except OSError as exc:
+        QMessageBox.critical(window, "Błąd eksportu", f"Nie udało się zapisać pliku: {exc}")
+        return False
+
+    QMessageBox.information(window, "Eksport zakończony", f"Zapisano plik: {path}")
+    return True
+
+
+def preview_final_output(window: PromptAssistantWindow) -> None:
+    """Pokazuje finalny output używany przez copy/export."""
+    result = _build_current_output(window)
+
+    dialog = QDialog(window)
+    dialog.setWindowTitle("Final preview")
+    dialog.setMinimumWidth(860)
+    dialog.setMinimumHeight(620)
+    layout = QVBoxLayout(dialog)
+
+    summary = QLabel(
+        f"Tokeny łącznie: {result.total_tokens} | "
+        f"Uwzględnione wpisy: {result.included_entries} | "
+        f"Pominięte wpisy: {result.excluded_entries}"
+    )
+    layout.addWidget(summary)
+
+    text = QPlainTextEdit(result.rendered_output)
+    text.setReadOnly(True)
+    layout.addWidget(text)
+
+    btn_layout = QHBoxLayout()
+    btn_layout.addStretch(1)
+
+    btn_copy = QPushButton("Kopiuj")
+    btn_copy.clicked.connect(lambda: QGuiApplication.clipboard().setText(text.toPlainText()))
+    btn_layout.addWidget(btn_copy)
+
+    btn_export = QPushButton("Eksportuj")
+    btn_export.clicked.connect(lambda: export_text(window, text.toPlainText()))
+    btn_layout.addWidget(btn_export)
+
+    btn_close = QPushButton("Zamknij")
+    btn_close.clicked.connect(dialog.accept)
+    btn_layout.addWidget(btn_close)
+
+    layout.addLayout(btn_layout)
+    dialog.exec_()
 
 
 def clear_all(window: PromptAssistantWindow) -> None:

--- a/prompt_assistant/gui/controllers.py
+++ b/prompt_assistant/gui/controllers.py
@@ -82,7 +82,15 @@ def _sync_directory_tree_entries(window: PromptAssistantWindow) -> None:
             dirs_to_remove.append(directory)
             continue
 
-        has_active_files = any(_get_file_status(f) == "active" for f in directory["files"])
+        active_files_rel = [f["rel"] for f in directory["files"] if _get_file_status(f) == "active"]
+        has_active_files = bool(active_files_rel)
+
+        tree_entry = get_entry(window.session, directory["tree_entry_id"])
+        if tree_entry is not None:
+            # `<directories>` ma odzwierciedlać wyłącznie aktywne pliki.
+            tree_entry.content = render_tree_structure(active_files_rel) if active_files_rel else "."
+            tree_entry.token_count_cache = None
+
         set_entry_inclusion(window.session, directory["tree_entry_id"], has_active_files)
 
     for directory in dirs_to_remove:

--- a/prompt_assistant/gui/preview_dialog.py
+++ b/prompt_assistant/gui/preview_dialog.py
@@ -62,9 +62,9 @@ class FilePreviewDialog(QDialog):
 
         # ---- Buttons -----------------------------------------------------------
         hbox = QHBoxLayout()
-        self.delete_btn = QPushButton("❌ Usuń plik z listy")
+        self.delete_btn = QPushButton("Remove File")
         self.delete_btn.clicked.connect(self._delete_file)
-        self.close_btn = QPushButton("Zamknij")
+        self.close_btn = QPushButton("Close")
         self.close_btn.clicked.connect(self.accept)
         hbox.addStretch(1)
         hbox.addWidget(self.delete_btn)

--- a/prompt_assistant/gui/preview_dialog.py
+++ b/prompt_assistant/gui/preview_dialog.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import (
     QDialog,
     QLabel,
@@ -38,20 +37,26 @@ class FilePreviewDialog(QDialog):
         # ---- UI ----------------------------------------------------------------
         vbox = QVBoxLayout(self)
 
+        token_info = count_tokens(file_obj["content"]) if file_obj.get("content") else 0
         header = QLabel(
             f"{self.window.windowTitle().split('—')[0]} — "
             f"{file_obj.get('name', file_obj.get('rel'))} "
-            f"— {count_tokens(file_obj['content'])} tokenów"
+            f"— {token_info} tokenów"
         )
         header.setWordWrap(True)
         vbox.addWidget(header)
 
-        self.viewer = QPlainTextEdit(file_obj["content"])
+        viewer_content = file_obj.get("content", "")
+        if file_obj.get("read_error"):
+            viewer_content = f"Błąd odczytu:\n{file_obj['read_error']}"
+        self.viewer = QPlainTextEdit(viewer_content)
         self.viewer.setReadOnly(True)
         vbox.addWidget(self.viewer, 1)
 
         self.exclude_cb = QCheckBox("✅ Wyklucz ten plik z promptu")
         self.exclude_cb.setChecked(file_obj["excluded"])
+        if file_obj.get("read_error"):
+            self.exclude_cb.setEnabled(False)
         self.exclude_cb.stateChanged.connect(self._toggle_exclude)
         vbox.addWidget(self.exclude_cb)
 
@@ -69,9 +74,16 @@ class FilePreviewDialog(QDialog):
     # --------------------------------------------------------------------- slots
     def _toggle_exclude(self, state: int) -> None:
         """Aktualizuje status excluded i formatowanie w liście."""
+        if self.file_obj.get("read_error"):
+            return
         # Late import to avoid circular import
         from prompt_assistant.core import get_entry, set_entry_inclusion
-        from prompt_assistant.gui.controllers import _sync_directory_tree_entries, _update_token_label
+        from prompt_assistant.gui.controllers import (
+            _refresh_item_visual,
+            _sync_directory_tree_entries,
+            _update_token_label,
+            apply_list_filters,
+        )
 
         self.file_obj["excluded"] = state == Qt.Checked
         include = not self.file_obj["excluded"]
@@ -84,10 +96,9 @@ class FilePreviewDialog(QDialog):
         if entry is not None:
             entry.token_count_cache = count_tokens(entry.content)
 
-        font: QFont = self.list_item.font()
-        font.setStrikeOut(self.file_obj["excluded"])
-        self.list_item.setFont(font)
+        _refresh_item_visual(self.list_item, self.file_obj)
         _update_token_label(self.window)
+        apply_list_filters(self.window)
 
     def _delete_file(self) -> None:
         """Usuwa plik ze wszystkich struktur + z UI."""

--- a/prompt_assistant/gui/preview_dialog.py
+++ b/prompt_assistant/gui/preview_dialog.py
@@ -70,9 +70,20 @@ class FilePreviewDialog(QDialog):
     def _toggle_exclude(self, state: int) -> None:
         """Aktualizuje status excluded i formatowanie w liście."""
         # Late import to avoid circular import
-        from prompt_assistant.gui.controllers import _update_token_label
+        from prompt_assistant.core import get_entry, set_entry_inclusion
+        from prompt_assistant.gui.controllers import _sync_directory_tree_entries, _update_token_label
 
         self.file_obj["excluded"] = state == Qt.Checked
+        include = not self.file_obj["excluded"]
+        set_entry_inclusion(self.window.session, self.file_obj["entry_id"], include)
+
+        # Przy plikach katalogowych tree-entry ma zależność od aktywności dzieci.
+        _sync_directory_tree_entries(self.window)
+
+        entry = get_entry(self.window.session, self.file_obj["entry_id"])
+        if entry is not None:
+            entry.token_count_cache = count_tokens(entry.content)
+
         font: QFont = self.list_item.font()
         font.setStrikeOut(self.file_obj["excluded"])
         self.list_item.setFont(font)
@@ -81,20 +92,10 @@ class FilePreviewDialog(QDialog):
     def _delete_file(self) -> None:
         """Usuwa plik ze wszystkich struktur + z UI."""
         # Late import to avoid circular import
-        from prompt_assistant.gui.controllers import _update_token_label
+        from prompt_assistant.gui.controllers import remove_file_from_session
 
         lw = self.window.files_list
         row = lw.row(self.list_item)
         lw.takeItem(row)
-
-        # Usuń z modelu
-        if self.file_obj in self.window.attached_files:
-            self.window.attached_files.remove(self.file_obj)
-        else:  # szukaj w katalogach
-            for d in self.window.attached_dirs:
-                if self.file_obj in d["files"]:
-                    d["files"].remove(self.file_obj)
-                    break
-
-        _update_token_label(self.window)
+        remove_file_from_session(self.window, self.file_obj)
         self.accept()

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -15,6 +15,8 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
+from prompt_assistant.core import Session
+
 __all__ = ["PromptAssistantWindow", "build_ui", "bind_signals"]
 
 
@@ -30,6 +32,7 @@ class PromptAssistantWindow(QMainWindow):
         self.attachments_tokens = 0
         self.total_tokens = 0
         self.ignore_gitignored = True
+        self.session = Session()
 
         build_ui(self)
 

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QLineEdit,
     QCheckBox,
+    QComboBox,
     QStatusBar,
     QLabel,
     QHBoxLayout,
@@ -73,6 +74,18 @@ def build_ui(window: PromptAssistantWindow) -> None:
     window.copy_button = QPushButton("Copy")
     bar.addWidget(window.copy_button)
 
+    window.preview_button = QPushButton("Final preview")
+    bar.addWidget(window.preview_button)
+
+    window.export_button = QPushButton("Export")
+    bar.addWidget(window.export_button)
+
+    window.output_format_combo = QComboBox()
+    window.output_format_combo.addItem("XML-like", "xml")
+    window.output_format_combo.addItem("Markdown blocks", "markdown")
+    window.output_format_combo.addItem("Plain text", "plain")
+    bar.addWidget(window.output_format_combo)
+
     window.clear_button = QPushButton("Clear")
     bar.addWidget(window.clear_button)
 
@@ -95,9 +108,12 @@ def bind_signals(window: PromptAssistantWindow) -> None:
         attach_files,
         attach_directory,
         copy_text,
+        export_text,
         clear_all,
         preview_file,
+        preview_final_output,
         show_token_distribution,
+        set_output_format,
     )
 
     window.text_edit.textChanged.connect(lambda: _update_token_label(window))
@@ -105,6 +121,11 @@ def bind_signals(window: PromptAssistantWindow) -> None:
     window.attach_button.clicked.connect(lambda: attach_files(window))
     window.attach_dir_button.clicked.connect(lambda: attach_directory(window))
     window.copy_button.clicked.connect(lambda: copy_text(window))
+    window.preview_button.clicked.connect(lambda: preview_final_output(window))
+    window.export_button.clicked.connect(lambda: export_text(window))
     window.clear_button.clicked.connect(lambda: clear_all(window))
     window.files_list.itemDoubleClicked.connect(lambda item: preview_file(window, item))
     window.show_token_dist_button.clicked.connect(lambda: show_token_distribution(window))
+    window.output_format_combo.currentIndexChanged.connect(
+        lambda idx: set_output_format(window, idx)
+    )

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -74,49 +74,55 @@ def build_ui(window: PromptAssistantWindow) -> None:
     window.status_filter_combo.addItem("Błędy", "error")
     filter_bar.addWidget(window.status_filter_combo)
 
-    bar = QHBoxLayout()
-    layout.addLayout(bar)
+    input_bar = QHBoxLayout()
+    layout.addLayout(input_bar)
 
     window.attach_button = QPushButton("Attach Files")
-    bar.addWidget(window.attach_button)
+    input_bar.addWidget(window.attach_button)
 
     window.attach_dir_button = QPushButton("Attach Directory")
-    bar.addWidget(window.attach_dir_button)
+    input_bar.addWidget(window.attach_dir_button)
 
     window.exclude_edit = QLineEdit()
     window.exclude_edit.setPlaceholderText("Wykluczenia: *.md, README.txt…")
-    bar.addWidget(window.exclude_edit, stretch=1)
+    input_bar.addWidget(window.exclude_edit, stretch=1)
 
     window.gitignore_checkbox = QCheckBox("Filtr .gitignore")
     window.gitignore_checkbox.setChecked(True)
-    bar.addWidget(window.gitignore_checkbox)
+    input_bar.addWidget(window.gitignore_checkbox)
+
+    output_bar = QHBoxLayout()
+    layout.addLayout(output_bar)
 
     window.copy_button = QPushButton("Copy")
-    bar.addWidget(window.copy_button)
+    output_bar.addWidget(window.copy_button)
 
     window.preview_button = QPushButton("Final preview")
-    bar.addWidget(window.preview_button)
+    output_bar.addWidget(window.preview_button)
 
     window.export_button = QPushButton("Export")
-    bar.addWidget(window.export_button)
+    output_bar.addWidget(window.export_button)
 
     window.output_format_combo = QComboBox()
     window.output_format_combo.addItem("XML-like", "xml")
     window.output_format_combo.addItem("Markdown blocks", "markdown")
     window.output_format_combo.addItem("Plain text", "plain")
-    bar.addWidget(window.output_format_combo)
+    output_bar.addWidget(window.output_format_combo)
 
-    window.bulk_include_button = QPushButton("Include selected")
-    bar.addWidget(window.bulk_include_button)
-
-    window.bulk_exclude_button = QPushButton("Exclude selected")
-    bar.addWidget(window.bulk_exclude_button)
-
-    window.bulk_remove_button = QPushButton("Remove selected")
-    bar.addWidget(window.bulk_remove_button)
+    output_bar.addStretch(1)
 
     window.clear_button = QPushButton("Clear")
-    bar.addWidget(window.clear_button)
+    output_bar.addWidget(window.clear_button)
+
+    bulk_bar = QHBoxLayout()
+    layout.addLayout(bulk_bar)
+
+    window.bulk_include_button = QPushButton("Include selected")
+    bulk_bar.addWidget(window.bulk_include_button)
+    window.bulk_exclude_button = QPushButton("Exclude selected")
+    bulk_bar.addWidget(window.bulk_exclude_button)
+    window.bulk_remove_button = QPushButton("Remove selected")
+    bulk_bar.addWidget(window.bulk_remove_button)
 
     # Status bar & token label
     status = QStatusBar()

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QPlainTextEdit,
     QListWidget,
+    QAbstractItemView,
     QPushButton,
     QLineEdit,
     QCheckBox,
@@ -52,7 +53,26 @@ def build_ui(window: PromptAssistantWindow) -> None:
     layout.addWidget(window.text_edit)
 
     window.files_list = QListWidget()
+    window.files_list.setSelectionMode(QAbstractItemView.ExtendedSelection)
     layout.addWidget(window.files_list)
+
+    filter_bar = QHBoxLayout()
+    layout.addLayout(filter_bar)
+
+    window.name_filter_edit = QLineEdit()
+    window.name_filter_edit.setPlaceholderText("Filtr nazwy")
+    filter_bar.addWidget(window.name_filter_edit)
+
+    window.ext_filter_edit = QLineEdit()
+    window.ext_filter_edit.setPlaceholderText("Rozszerzenie (np. .py)")
+    filter_bar.addWidget(window.ext_filter_edit)
+
+    window.status_filter_combo = QComboBox()
+    window.status_filter_combo.addItem("Wszystkie", "all")
+    window.status_filter_combo.addItem("Aktywne", "active")
+    window.status_filter_combo.addItem("Wykluczone", "excluded")
+    window.status_filter_combo.addItem("Błędy", "error")
+    filter_bar.addWidget(window.status_filter_combo)
 
     bar = QHBoxLayout()
     layout.addLayout(bar)
@@ -86,6 +106,15 @@ def build_ui(window: PromptAssistantWindow) -> None:
     window.output_format_combo.addItem("Plain text", "plain")
     bar.addWidget(window.output_format_combo)
 
+    window.bulk_include_button = QPushButton("Include selected")
+    bar.addWidget(window.bulk_include_button)
+
+    window.bulk_exclude_button = QPushButton("Exclude selected")
+    bar.addWidget(window.bulk_exclude_button)
+
+    window.bulk_remove_button = QPushButton("Remove selected")
+    bar.addWidget(window.bulk_remove_button)
+
     window.clear_button = QPushButton("Clear")
     bar.addWidget(window.clear_button)
 
@@ -108,12 +137,16 @@ def bind_signals(window: PromptAssistantWindow) -> None:
         attach_files,
         attach_directory,
         copy_text,
+        bulk_exclude_selected,
+        bulk_include_selected,
+        bulk_remove_selected,
         export_text,
         clear_all,
         preview_file,
         preview_final_output,
         show_token_distribution,
         set_output_format,
+        apply_list_filters,
     )
 
     window.text_edit.textChanged.connect(lambda: _update_token_label(window))
@@ -123,9 +156,15 @@ def bind_signals(window: PromptAssistantWindow) -> None:
     window.copy_button.clicked.connect(lambda: copy_text(window))
     window.preview_button.clicked.connect(lambda: preview_final_output(window))
     window.export_button.clicked.connect(lambda: export_text(window))
+    window.bulk_include_button.clicked.connect(lambda: bulk_include_selected(window))
+    window.bulk_exclude_button.clicked.connect(lambda: bulk_exclude_selected(window))
+    window.bulk_remove_button.clicked.connect(lambda: bulk_remove_selected(window))
     window.clear_button.clicked.connect(lambda: clear_all(window))
     window.files_list.itemDoubleClicked.connect(lambda item: preview_file(window, item))
     window.show_token_dist_button.clicked.connect(lambda: show_token_distribution(window))
     window.output_format_combo.currentIndexChanged.connect(
         lambda idx: set_output_format(window, idx)
     )
+    window.name_filter_edit.textChanged.connect(lambda: apply_list_filters(window))
+    window.ext_filter_edit.textChanged.connect(lambda: apply_list_filters(window))
+    window.status_filter_combo.currentIndexChanged.connect(lambda _idx: apply_list_filters(window))

--- a/prompt_assistant/gui/ui.py
+++ b/prompt_assistant/gui/ui.py
@@ -77,10 +77,10 @@ def build_ui(window: PromptAssistantWindow) -> None:
     bar = QHBoxLayout()
     layout.addLayout(bar)
 
-    window.attach_button = QPushButton("Załącz pliki")
+    window.attach_button = QPushButton("Attach Files")
     bar.addWidget(window.attach_button)
 
-    window.attach_dir_button = QPushButton("Załącz katalog")
+    window.attach_dir_button = QPushButton("Attach Directory")
     bar.addWidget(window.attach_dir_button)
 
     window.exclude_edit = QLineEdit()
@@ -125,7 +125,7 @@ def build_ui(window: PromptAssistantWindow) -> None:
     status.addPermanentWidget(window.token_label)
 
     # Nowy przycisk: Pokaż rozkład tokenów
-    window.show_token_dist_button = QPushButton("Pokaż rozkład tokenów")
+    window.show_token_dist_button = QPushButton("Show Token Breakdown")
     status.addPermanentWidget(window.show_token_dist_button)
 
 

--- a/spec.md
+++ b/spec.md
@@ -84,8 +84,11 @@ Kluczowe komponenty i odpowiedzialności:
 - Uzasadnienie: PRD wymaga płynności pracy na większych katalogach i szybkiej aktualizacji liczników.
 - Konsekwencje: potrzebna strategia invalidacji cache po zmianach stanu sesji.
 
+- Decyzja: Domyślny profil outputu dla copy/export to XML-like.
+- Uzasadnienie: zachowuje kompatybilność wsteczną z dotychczasowym formatem bloków `<file ...>`.
+- Konsekwencje: użytkownik może ręcznie przełączyć się na profile markdown/plain zależnie od workflow.
+
 TODO: [Jaka ma być dokładna polityka sortowania/kolejności wpisów w finalnym outputcie przy mieszanym imporcie plików i katalogów?]
-TODO: [Czy profile formatu outputu mają być globalnym ustawieniem sesji czy wybierane jednorazowo per eksport/kopiowanie?]
 
 ---
 

--- a/spec.md
+++ b/spec.md
@@ -68,6 +68,8 @@ Kluczowe komponenty i odpowiedzialności:
 - Token service: liczenie i progi ostrzegawcze.
 - Import/reporting: ładowanie katalogu z raportem dodanych/pominiętych plików i powodów.
 - Preview/export bridge: spójny kanał do podglądu, kopiowania i zapisu pliku.
+- Minimalny CLI hook: uruchomienie renderowania bez GUI dla prostych workflow terminalowych.
+- CI pipeline: automatyczna walidacja testów i check kompilacji.
 
 ---
 
@@ -87,6 +89,14 @@ Kluczowe komponenty i odpowiedzialności:
 - Decyzja: Domyślny profil outputu dla copy/export to XML-like.
 - Uzasadnienie: zachowuje kompatybilność wsteczną z dotychczasowym formatem bloków `<file ...>`.
 - Konsekwencje: użytkownik może ręcznie przełączyć się na profile markdown/plain zależnie od workflow.
+
+- Decyzja: Bazowy CI obejmuje `unittest` i check kompilacji (`compileall`).
+- Uzasadnienie: szybka walidacja regresji i podstawowa kontrola jakości bez rozbudowy narzędzi.
+- Konsekwencje: każda zmiana przechodzi przez jednolity minimalny pipeline.
+
+- Decyzja: Dodany minimalny punkt zaczepienia CLI bez zmiany głównego entrypointu GUI.
+- Uzasadnienie: przygotowuje fundament pod dalszy rozwój narzędzia terminalowego.
+- Konsekwencje: logika renderowania pozostaje współdzielona przez GUI i CLI przez warstwę core.
 
 TODO: [Jaka ma być dokładna polityka sortowania/kolejności wpisów w finalnym outputcie przy mieszanym imporcie plików i katalogów?]
 

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,121 @@
+# Specyfikacja techniczna
+
+## Cel
+PromptGlue v2 to lokalna aplikacja desktopowa do budowania jednego, kontrolowanego wejścia dla modeli LLM z treści promptu oraz plików/katalogów.
+
+- Rozwiązuje problem niespójności i nieprzewidywalności przy pracy z wieloma plikami (szczególnie przy usuwaniu i wykluczaniu).
+- Główni użytkownicy: developerzy, DevOps/Cloud engineers i osoby pracujące na repozytoriach.
+- Poza zakresem v2: chmura/synchronizacja online, integracje z API LLM, multi-user collaboration, pełna wersja webowa.
+
+---
+
+## Zakres funkcjonalny (high-level)
+Kluczowe funkcjonalności v2:
+
+- ładowanie pojedynczych plików i całych katalogów (rekurencyjnie),
+- respektowanie `.gitignore`, własnych wzorców wykluczeń i pomijanie binarek,
+- zarządzanie listą wejść (remove / exclude / include),
+- budowanie finalnego outputu z aktualnego stanu sesji,
+- podgląd finalnego outputu przed kopiowaniem,
+- kopiowanie do schowka i eksport do `.md` / `.txt`,
+- kontrola tokenów (prompt, pliki, suma, ostrzeżenia).
+
+Główne przepływy użytkownika:
+
+- użytkownik wpisuje instrukcję, dodaje pliki/katalog, selekcjonuje kontekst, sprawdza preview i kopiuje/eksportuje wynik,
+- użytkownik iteracyjnie usuwa/wyklucza elementy i oczekuje, że finalny output zawsze odzwierciedla stan listy wejść.
+
+Czego aplikacja nie robi:
+
+- nie wysyła danych do modeli AI ani zewnętrznych API,
+- nie realizuje funkcji collaborative/online,
+- nie wykonuje automatycznego pipeline'u AI (np. auto-summarization).
+
+Bez wchodzenia w szczegóły implementacyjne.
+
+---
+
+## Architektura i przepływ danych
+Docelowy model koncepcyjny:
+
+1. Główne komponenty systemu
+- UI layer (PyQt): prezentacja stanu i obsługa zdarzeń użytkownika.
+- Application layer: use-case'y operacyjne (add/remove/exclude/build/preview/export).
+- Domain/Core layer: model sesji, renderer outputu, logika tokenów i walidacji wejścia.
+- Infrastructure layer: filesystem, clipboard, eksport plików, konfiguracja.
+
+2. Przepływ danych między komponentami
+- Zdarzenie z UI aktualizuje stan sesji.
+- Renderer buduje finalny output na podstawie bieżącej sesji.
+- Preview/copy/export korzystają z tego samego wyniku renderowania.
+- Token service wylicza metryki dla aktywnych elementów sesji.
+
+3. Granice odpowiedzialności
+- UI nie utrzymuje logiki domenowej jako źródła prawdy.
+- Core odpowiada za spójność i deterministyczne generowanie wyniku.
+- Integracje systemowe (plik/schowek) są odseparowane od logiki budowania outputu.
+
+---
+
+## Komponenty techniczne
+Kluczowe komponenty i odpowiedzialności:
+
+- `Session`: źródło prawdy o aktualnym stanie promptu i listy wejść.
+- `Entry`: pojedynczy element wejścia (plik/element pochodzący z importu katalogu).
+- `BuildResult`: wynik renderowania (tekst, tokeny, ostrzeżenia/błędy, statystyki include/exclude).
+- Prompt renderer: deterministyczna budowa finalnego outputu od zera.
+- Ignore engine: `.gitignore` i custom patterns.
+- Token service: liczenie i progi ostrzegawcze.
+- Import/reporting: ładowanie katalogu z raportem dodanych/pominiętych plików i powodów.
+- Preview/export bridge: spójny kanał do podglądu, kopiowania i zapisu pliku.
+
+---
+
+## Decyzje techniczne
+- Decyzja: Python + PyQt pozostają bazowym stackiem v2 (bez pełnego rewrite'u).
+- Uzasadnienie: PRD wskazuje na potrzebę szybkiego zwiększenia niezawodności i utrzymania ciągłości rozwoju.
+- Konsekwencje: rozwój koncentruje się na wydzieleniu core od GUI i testowalności logiki domenowej.
+
+- Decyzja: Finalny output jest renderowany od zera na podstawie `Session`; `BuildResult` nie jest źródłem prawdy.
+- Uzasadnienie: eliminuje krytyczny rozjazd między listą plików a treścią wynikową.
+- Konsekwencje: copy/preview/export muszą używać wspólnego pipeline'u renderowania.
+
+- Decyzja: Wprowadzenie cache tokenów per entry jako optymalizacji v2.
+- Uzasadnienie: PRD wymaga płynności pracy na większych katalogach i szybkiej aktualizacji liczników.
+- Konsekwencje: potrzebna strategia invalidacji cache po zmianach stanu sesji.
+
+TODO: [Jaka ma być dokładna polityka sortowania/kolejności wpisów w finalnym outputcie przy mieszanym imporcie plików i katalogów?]
+TODO: [Czy profile formatu outputu mają być globalnym ustawieniem sesji czy wybierane jednorazowo per eksport/kopiowanie?]
+
+---
+
+## Jakość i kryteria akceptacji
+Wymagania jakościowe v2:
+
+- brak znanego rozjazdu między listą aktywnych wejść a finalnym outputem,
+- deterministyczne renderowanie outputu,
+- jawne raportowanie błędów odczytu i pominięć,
+- testowalny core niezależny od GUI,
+- testy regresyjne dla remove/exclude i build pipeline,
+- zgodność preview/copy/export (ten sam wynik),
+- uruchamianie i testowanie opisane w README.
+
+---
+
+## Zasady zmian i ewolucji
+- zmiany funkcjonalne -> aktualizacja `ROADMAP.md`
+- zmiany architektoniczne -> aktualizacja tej specyfikacji
+- nowe zależności -> wpis do `## Decyzje techniczne`
+- refactory tylko w ramach aktualnego milestone'u
+
+---
+
+## Powiązanie z roadmapą
+- Szczegóły milestone'ów i ich statusy znajdują się w `ROADMAP.md`.
+
+---
+
+## Status specyfikacji
+- Data utworzenia: 2025-03-07
+- Ostatnia aktualizacja: 2026-04-01
+- Aktualny zakres obowiązywania: PromptGlue v2 (stabilność, spójność outputu, ergonomia i fundament pod dalszy rozwój)

--- a/tests/test_cli_hook.py
+++ b/tests/test_cli_hook.py
@@ -1,0 +1,32 @@
+"""Testy minimalnego hooka CLI (M4)."""
+from __future__ import annotations
+
+import unittest
+
+from prompt_assistant.cli import render_from_sources
+from prompt_assistant.core import OutputFormat
+
+
+class CliHookTests(unittest.TestCase):
+    def test_render_from_sources_xml(self) -> None:
+        output = render_from_sources(
+            "Instrukcja",
+            [("a.py", "print('a')"), ("b.py", "print('b')")],
+            OutputFormat.XML,
+        )
+        self.assertIn("Instrukcja", output)
+        self.assertIn("<file path='a.py'>", output)
+        self.assertIn("<file path='b.py'>", output)
+
+    def test_render_from_sources_plain(self) -> None:
+        output = render_from_sources(
+            "",
+            [("a.py", "print('a')")],
+            OutputFormat.PLAIN,
+        )
+        self.assertIn("FILE: a.py", output)
+        self.assertNotIn("<file path='a.py'>", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_renderer.py
+++ b/tests/test_core_renderer.py
@@ -1,0 +1,65 @@
+"""Testy regresyjne dla warstwy core (M1)."""
+from __future__ import annotations
+
+import unittest
+
+from prompt_assistant.core import (
+    EntrySourceType,
+    Session,
+    add_entry,
+    build_output,
+    create_entry,
+    remove_entry,
+    set_entry_inclusion,
+)
+
+
+class CoreRendererTests(unittest.TestCase):
+    def test_removed_file_is_not_rendered(self) -> None:
+        session = Session(prompt_text="Instrukcja")
+        file_a = create_entry("a.py", EntrySourceType.FILE, "print('a')")
+        file_b = create_entry("b.py", EntrySourceType.FILE, "print('b')")
+        add_entry(session, file_a)
+        add_entry(session, file_b)
+
+        removed = remove_entry(session, file_b.entry_id)
+        self.assertTrue(removed)
+
+        result = build_output(session)
+        self.assertIn("<file path='a.py'>", result.rendered_output)
+        self.assertNotIn("<file path='b.py'>", result.rendered_output)
+
+    def test_excluded_file_is_not_rendered(self) -> None:
+        session = Session(prompt_text="Instrukcja")
+        file_a = create_entry("a.py", EntrySourceType.FILE, "print('a')")
+        file_b = create_entry("b.py", EntrySourceType.FILE, "print('b')")
+        add_entry(session, file_a)
+        add_entry(session, file_b)
+
+        changed = set_entry_inclusion(session, file_b.entry_id, False)
+        self.assertTrue(changed)
+
+        result = build_output(session)
+        self.assertIn("<file path='a.py'>", result.rendered_output)
+        self.assertNotIn("<file path='b.py'>", result.rendered_output)
+        self.assertEqual(result.included_entries, 1)
+        self.assertEqual(result.excluded_entries, 1)
+
+    def test_render_order_is_deterministic(self) -> None:
+        session = Session(prompt_text="Instrukcja")
+        first = create_entry("first.txt", EntrySourceType.FILE, "1")
+        second = create_entry("second.txt", EntrySourceType.FILE, "2")
+        add_entry(session, first)
+        add_entry(session, second)
+
+        result = build_output(session)
+        first_index = result.rendered_output.find("<file path='first.txt'>")
+        second_index = result.rendered_output.find("<file path='second.txt'>")
+
+        self.assertGreaterEqual(first_index, 0)
+        self.assertGreaterEqual(second_index, 0)
+        self.assertLess(first_index, second_index)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dir_tree_sync.py
+++ b/tests/test_dir_tree_sync.py
@@ -1,0 +1,76 @@
+"""Regression tests for directory tree sync with exclude/remove."""
+from __future__ import annotations
+
+import unittest
+
+from prompt_assistant.core import EntrySourceType, Session, add_entry, create_entry, get_entry
+from prompt_assistant.gui.controllers import _sync_directory_tree_entries
+
+
+class _DummyWindow:
+    def __init__(self) -> None:
+        self.session = Session()
+        self.attached_dirs = []
+
+
+class DirectoryTreeSyncTests(unittest.TestCase):
+    def test_tree_content_excludes_excluded_files(self) -> None:
+        window = _DummyWindow()
+
+        tree_entry = create_entry("repo/.tree", EntrySourceType.DIRECTORY_TREE, ".")
+        add_entry(window.session, tree_entry)
+
+        file_a = create_entry("a.py", EntrySourceType.DIRECTORY_FILE, "print('a')")
+        file_b = create_entry("b.py", EntrySourceType.DIRECTORY_FILE, "print('b')")
+        add_entry(window.session, file_a)
+        add_entry(window.session, file_b)
+
+        window.attached_dirs.append(
+            {
+                "name": "repo",
+                "tree": ".",
+                "tree_entry_id": tree_entry.entry_id,
+                "files": [
+                    {"rel": "a.py", "excluded": False},
+                    {"rel": "b.py", "excluded": True},
+                ],
+            }
+        )
+
+        _sync_directory_tree_entries(window)
+
+        updated_tree = get_entry(window.session, tree_entry.entry_id)
+        self.assertIsNotNone(updated_tree)
+        self.assertIn("a.py", updated_tree.content)
+        self.assertNotIn("b.py", updated_tree.content)
+
+    def test_tree_is_disabled_when_all_files_excluded(self) -> None:
+        window = _DummyWindow()
+
+        tree_entry = create_entry("repo/.tree", EntrySourceType.DIRECTORY_TREE, ".")
+        add_entry(window.session, tree_entry)
+
+        file_a = create_entry("a.py", EntrySourceType.DIRECTORY_FILE, "print('a')")
+        add_entry(window.session, file_a)
+
+        window.attached_dirs.append(
+            {
+                "name": "repo",
+                "tree": ".",
+                "tree_entry_id": tree_entry.entry_id,
+                "files": [
+                    {"rel": "a.py", "excluded": True},
+                ],
+            }
+        )
+
+        _sync_directory_tree_entries(window)
+
+        updated_tree = get_entry(window.session, tree_entry.entry_id)
+        self.assertIsNotNone(updated_tree)
+        self.assertEqual(updated_tree.content, ".")
+        self.assertFalse(updated_tree.include_in_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_m3_filters_bulk_report.py
+++ b/tests/test_m3_filters_bulk_report.py
@@ -1,0 +1,89 @@
+"""Testy Milestone 3: filtry, masowe akcje i raporty."""
+from __future__ import annotations
+
+import unittest
+
+from prompt_assistant.core import (
+    EntrySourceType,
+    FileListRecord,
+    Session,
+    add_entry,
+    build_import_report,
+    create_entry,
+    exclude_entries,
+    include_entries,
+    matches_filters,
+    remove_entries,
+)
+
+
+class M3FiltersBulkReportTests(unittest.TestCase):
+    def test_matches_filters_by_name_extension_and_status(self) -> None:
+        record = FileListRecord(display_name="repo/src/main.py", extension=".py", status="active")
+
+        self.assertTrue(
+            matches_filters(
+                record,
+                name_query="main",
+                extension_query="py",
+                status_filter="active",
+            )
+        )
+        self.assertFalse(
+            matches_filters(
+                record,
+                name_query="main",
+                extension_query="md",
+                status_filter="active",
+            )
+        )
+        self.assertFalse(
+            matches_filters(
+                record,
+                name_query="readme",
+                extension_query="py",
+                status_filter="active",
+            )
+        )
+
+    def test_bulk_include_exclude_and_remove(self) -> None:
+        session = Session()
+        a = create_entry("a.py", EntrySourceType.FILE, "a")
+        b = create_entry("b.py", EntrySourceType.FILE, "b")
+        c = create_entry("c.py", EntrySourceType.FILE, "c")
+        add_entry(session, a)
+        add_entry(session, b)
+        add_entry(session, c)
+
+        excluded = exclude_entries(session, [a.entry_id, b.entry_id])
+        self.assertEqual(excluded, 2)
+        self.assertFalse(a.include_in_output)
+        self.assertFalse(b.include_in_output)
+
+        included = include_entries(session, [a.entry_id])
+        self.assertEqual(included, 1)
+        self.assertTrue(a.include_in_output)
+
+        removed = remove_entries(session, [c.entry_id])
+        self.assertEqual(removed, 1)
+        self.assertEqual(len(session.entries), 2)
+
+    def test_import_report_contains_reasons(self) -> None:
+        report = build_import_report(
+            added_count=5,
+            skipped_git=2,
+            skipped_custom=1,
+            skipped_binary=3,
+            read_errors=["a.py: Permission denied", "b.py: Decode error"],
+        )
+
+        self.assertIn("Dodano: 5", report)
+        self.assertIn("Pominięto .gitignore: 2", report)
+        self.assertIn("Pominięto custom: 1", report)
+        self.assertIn("Pominięto binarne: 3", report)
+        self.assertIn("Błędy odczytu: 2", report)
+        self.assertIn("a.py: Permission denied", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_renderer_formats_and_export.py
+++ b/tests/test_renderer_formats_and_export.py
@@ -1,0 +1,43 @@
+"""Testy dla profili renderowania i eksportu (M2)."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import mock_open, patch
+
+from prompt_assistant.core import EntrySourceType, OutputFormat, Session, add_entry, build_output, create_entry
+from prompt_assistant.exporter import export_text_to_file
+
+
+class RendererFormatsAndExportTests(unittest.TestCase):
+    def _build_sample_session(self, output_format: OutputFormat) -> Session:
+        session = Session(prompt_text="Instrukcja", output_format=output_format)
+        entry = create_entry("src/main.py", EntrySourceType.FILE, "print('hello')")
+        add_entry(session, entry)
+        return session
+
+    def test_xml_like_profile(self) -> None:
+        result = build_output(self._build_sample_session(OutputFormat.XML))
+        self.assertIn("<file path='src/main.py'>", result.rendered_output)
+        self.assertIn("</file>", result.rendered_output)
+
+    def test_markdown_profile(self) -> None:
+        result = build_output(self._build_sample_session(OutputFormat.MARKDOWN))
+        self.assertIn("### src/main.py", result.rendered_output)
+        self.assertIn("```", result.rendered_output)
+
+    def test_plain_text_profile(self) -> None:
+        result = build_output(self._build_sample_session(OutputFormat.PLAIN))
+        self.assertIn("FILE: src/main.py", result.rendered_output)
+        self.assertNotIn("<file path='src/main.py'>", result.rendered_output)
+
+    def test_export_writes_utf8_file(self) -> None:
+        mocked_open = mock_open()
+        with patch("builtins.open", mocked_open):
+            export_text_to_file("wynik.md", "abc")
+
+        mocked_open.assert_called_once_with("wynik.md", "w", encoding="utf-8")
+        mocked_open.return_value.__enter__.return_value.write.assert_called_once_with("abc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zakres
- wdrożenie milestone'ów M1-M4
- poprawki UX (układ akcji i spójność etykiet)
- fix niespójności sekcji `<directories>` przy exclude/remove
- testy regresyjne i rozszerzenie walidacji

## Walidacja
- `uv run python -m unittest discover -s tests -p "test_*.py"`

## Dokumentacja
- aktualizacja `ROADMAP.md`, `STATUS.md`, `README.md`, `spec.md` zgodnie ze stanem repo
